### PR TITLE
Allow components with Unit props to be constructed without any parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 **/.DS_Store
 core/src/gen
 node_modules/
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## vNEXT
++ Components and external components with a `Props` type of `Unit` can now be constructed without any parameters, instead of having to pass in `()` as props [PR #12](https://github.com/shadaj/slinky/pull/12)
+
+## v0.1.0
++ Initial release

--- a/core/src/main/scala/me/shadaj/slinky/core/BaseComponent.scala
+++ b/core/src/main/scala/me/shadaj/slinky/core/BaseComponent.scala
@@ -37,6 +37,12 @@ abstract class BaseComponent {
 }
 
 object BaseComponent {
+  implicit class ProplessComponent[C <: BaseComponent { type Props = Unit }](val c: C) {
+    def apply(key: String = null, ref: c.Def => Unit = null)(implicit constructorTag: ConstructorTag[c.Def]): ReactElement = {
+      c.apply((), key, ref)(constructorTag, implicitly[Writer[Unit]])
+    }
+  }
+
   private var componentConstructorMiddleware = (constructor: js.Object, _: js.Object) => {
     constructor
   }

--- a/core/src/main/scala/me/shadaj/slinky/core/ExternalComponent.scala
+++ b/core/src/main/scala/me/shadaj/slinky/core/ExternalComponent.scala
@@ -56,6 +56,14 @@ abstract class ExternalComponent {
   }
 }
 
+object ExternalComponent {
+  implicit class ProplessExternalComponent(val c: ExternalComponent { type Props = Unit }) {
+    def apply(key: String = null, ref: js.Object => Unit = null): BuildingComponent[c.Props, Any] = {
+      c.apply((), key, ref)
+    }
+  }
+}
+
 abstract class ExternalComponentWithTagMods {
   type Props
   type Element
@@ -63,6 +71,15 @@ abstract class ExternalComponentWithTagMods {
   val component: String | js.Object
 
   def apply(p: Props, tagMods: AttrPair[Element]*): BuildingComponent[Props, Element] = {
+    // no need to take key or ref here because those can be passed in through attributes
     new BuildingComponent(component, p, null, null, tagMods)
+  }
+}
+
+object ExternalComponentWithTagMods {
+  implicit class ProplessExternalComponentWithTagMods[C <: ExternalComponentWithTagMods { type Props = Unit }](val c: C) {
+    def apply(tagMods: AttrPair[c.Element]*): BuildingComponent[c.Props, c.Element] = {
+      c.apply((), tagMods: _*)
+    }
   }
 }

--- a/tests/src/test/scala/me/shadaj/slinky/core/ComponentTest.scala
+++ b/tests/src/test/scala/me/shadaj/slinky/core/ComponentTest.scala
@@ -33,6 +33,20 @@ object TestComponent extends Component {
   }
 }
 
+object NoPropsComponent extends Component {
+  type Props = Unit
+  type State = Int
+
+  @ScalaJSDefined
+  class Def(jsProps: js.Object) extends Definition(jsProps) {
+    override def initialState: Int = 0
+
+    override def render(): ReactElement = {
+      null
+    }
+  }
+}
+
 class ComponentTest extends AsyncFunSuite {
   test("setState given function is applied") {
     val promise: Promise[Assertion] = Promise()
@@ -43,5 +57,9 @@ class ComponentTest extends AsyncFunSuite {
     )
 
     promise.future
+  }
+
+  test("Can construct a component taking Unit props with no arguments") {
+    assertCompiles("""NoPropsComponent()""")
   }
 }

--- a/tests/src/test/scala/me/shadaj/slinky/core/ExternalComponentTest.scala
+++ b/tests/src/test/scala/me/shadaj/slinky/core/ExternalComponentTest.scala
@@ -18,18 +18,18 @@ object ExternalSimpleWithTagMods extends ExternalComponentWithTagMods {
 
 class ExternalComponentTest extends FunSuite {
   test("Implicit macro to shortcut ExternalComponent can be invoked") {
-    div(
-      ExternalSimple(())
-    )
-
-    assert(true)
+    assertCompiles("""div(ExternalSimple())""")
   }
 
   test("Implicit macro to shortcut ExternalComponentWithTagMods can be invoked") {
-    div(
-      ExternalSimpleWithTagMods(())
-    )
+    assertCompiles("""div(ExternalSimpleWithTagMods())""")
+  }
 
-    assert(true)
+  test("Can construct an external component taking Unit props with no arguments") {
+    assertCompiles("""ExternalSimple()""")
+  }
+
+  test("Can construct an external component taking Unit props and tag mods with no arguments") {
+    assertCompiles("""ExternalSimpleWithTagMods()""")
   }
 }


### PR DESCRIPTION
Previously, to construct a component or external component taking `Unit` for props, you would have to pass in `()` as props. Now, such components can be constructed without any arguments to the apply method.

`MyComponent(())` -> `MyComponent()` (the original apply method still works)

This currently doesn't work in IntelliJ, but there is an issue opened https://youtrack.jetbrains.com/issue/SCL-12375