### PR TITLE
Go back to using react-proxy for hot loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 + **BREAKING**: Rename `ExternalComponentWithTagMods` to `ExternalComponentWithAttributes` and take attributes as a curried parameter instead of an extra parameter after `Props` [PR #26](https://github.com/shadaj/slinky/pull/26)
 + Have mouse attributes such as `onMouseDown` take a `MouseEvent` instead of just an `Event` [PR #27](https://github.com/shadaj/slinky/pull/27)
 + Add support for generating `Reader` and `Writer` for sealed traits, value classes, and case objects (through a Magnolia upgrade) [PR #45](https://github.com/shadaj/slinky/pull/45)
-+ Re-implement hot loading in Slinky itself to support more complex cases such as sealed traits [PR 48](https://github.com/shadaj/slinky/pull/48)
 
 ### `@react` macro annotation (experimental)
 One of Slinky's main goals is to have React components written in Scala look very similar to ES6. In version 0.1.x, Slinky required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 + **BREAKING**: Rename `ExternalComponentWithTagMods` to `ExternalComponentWithAttributes` and take attributes as a curried parameter instead of an extra parameter after `Props` [PR #26](https://github.com/shadaj/slinky/pull/26)
 + Have mouse attributes such as `onMouseDown` take a `MouseEvent` instead of just an `Event` [PR #27](https://github.com/shadaj/slinky/pull/27)
 + Add support for generating `Reader` and `Writer` for sealed traits, value classes, and case objects (through a Magnolia upgrade) [PR #45](https://github.com/shadaj/slinky/pull/45)
++ Fix bug with hot loading not updating instances of readers and writers [PR #49](https://github.com/shadaj/slinky/pull/49)
 
 ### `@react` macro annotation (experimental)
 One of Slinky's main goals is to have React components written in Scala look very similar to ES6. In version 0.1.x, Slinky required

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the dependencies that match your application:
 ```scala
 libraryDependencies += "me.shadaj" %%% "slinky-core" % "0.1.1" // core React functionality, no React DOM
 libraryDependencies += "me.shadaj" %%% "slinky-web" % "0.1.1" // React DOM, HTML and SVG tags
-libraryDependencies += "me.shadaj" %%% "slinky-hot" % "0.1.1" // Hot loading with Webpack
+libraryDependencies += "me.shadaj" %%% "slinky-hot" % "0.1.1" // Hot loading, requires react-proxy package
 libraryDependencies += "me.shadaj" %%% "slinky-scalajsreact-interop" % "0.1.1" // Interop with japgolly/scalajs-react
 
 // optional, enables the @react macro annotation API

--- a/core/src/main/scala/me/shadaj/slinky/core/DefinitionBase.scala
+++ b/core/src/main/scala/me/shadaj/slinky/core/DefinitionBase.scala
@@ -14,29 +14,9 @@ abstract class DefinitionBase[Props, State](jsProps: js.Object)(implicit propsRe
   def initialState: State
 
   this.asInstanceOf[PrivateComponentClass].stateR = {
-    BaseComponentWrapper.getWrittenInitialStateMiddleware.flatMap { fn =>
-      val name = this.asInstanceOf[js.Dynamic].__proto__.constructor.__fullName.asInstanceOf[String]
-      fn(name).flatMap { previousState =>
-        try {
-          val readBack = stateReader.read(previousState, root = true)
-          Some(js.Dynamic.literal(__ = readBack.asInstanceOf[js.Any]))
-        } catch {
-          case e: Throwable =>
-            e.printStackTrace()
-            println("[Slinky Hot Loading] Previous state is incompatible! Using initial state.")
-            None
-        }
-      }
-    }.getOrElse {
-      js.Dynamic.literal(__ = initialState.asInstanceOf[js.Any])
-    }
-  }
-
-  BaseComponentWrapper.writtenStateMiddleware.foreach { fn =>
-    val name = this.asInstanceOf[js.Dynamic].__proto__.constructor.__fullName.asInstanceOf[String]
-    fn.apply(name, () => {
-      stateWriter.write(state, root = true)
-    })
+    if (BaseComponentWrapper.scalaComponentWritingEnabled) {
+      stateWriter.write(initialState, root = true)
+    } else js.Dynamic.literal(__ = initialState.asInstanceOf[js.Any])
   }
 
   @JSName("props_scala")
@@ -51,7 +31,9 @@ abstract class DefinitionBase[Props, State](jsProps: js.Object)(implicit propsRe
 
   @JSName("setState_scala")
   @inline final def setState(s: State): Unit = {
-    val stateObject = js.Dynamic.literal(__ = s.asInstanceOf[js.Any])
+    val stateObject = if (BaseComponentWrapper.scalaComponentWritingEnabled) {
+      stateWriter.write(s, root = true)
+    } else js.Dynamic.literal(__ = s.asInstanceOf[js.Any])
 
     this.asInstanceOf[PrivateComponentClass].setStateR(stateObject)
   }
@@ -60,13 +42,17 @@ abstract class DefinitionBase[Props, State](jsProps: js.Object)(implicit propsRe
   @inline final def setState(fn: (State, Props) => State): Unit = {
     this.asInstanceOf[PrivateComponentClass].setStateR((ps: js.Object, p: js.Object) => {
       val s = fn(stateReader.read(ps, true), propsReader.read(p, true))
-      js.Dynamic.literal(__ = s.asInstanceOf[js.Any])
+      if (BaseComponentWrapper.scalaComponentWritingEnabled) {
+        stateWriter.write(s, root = true)
+      } else js.Dynamic.literal(__ = s.asInstanceOf[js.Any])
     })
   }
 
   @JSName("setState_scala")
   @inline final def setState(s: State, callback: js.Function0[Unit]): Unit = {
-    val stateObject = js.Dynamic.literal(__ = s.asInstanceOf[js.Any])
+    val stateObject = if (BaseComponentWrapper.scalaComponentWritingEnabled) {
+      stateWriter.write(s, root = true)
+    } else js.Dynamic.literal(__ = s.asInstanceOf[js.Any])
     this.asInstanceOf[PrivateComponentClass].setStateR(stateObject, callback)
   }
 
@@ -74,7 +60,9 @@ abstract class DefinitionBase[Props, State](jsProps: js.Object)(implicit propsRe
   @inline final def setState(fn: (State, Props) => State, callback: js.Function0[Unit]): Unit = {
     this.asInstanceOf[PrivateComponentClass].setStateR((ps: js.Object, p: js.Object) => {
       val s = fn(stateReader.read(ps, true), propsReader.read(p, true))
-      js.Dynamic.literal(__ = s.asInstanceOf[js.Any])
+      if (BaseComponentWrapper.scalaComponentWritingEnabled) {
+        stateWriter.write(s, root = true)
+      } else js.Dynamic.literal(__ = s.asInstanceOf[js.Any])
     }, callback)
   }
 

--- a/core/src/main/scala/me/shadaj/slinky/core/DefinitionBase.scala
+++ b/core/src/main/scala/me/shadaj/slinky/core/DefinitionBase.scala
@@ -7,10 +7,12 @@ import scala.scalajs.js.JSON
 import scala.scalajs.js.annotation.{JSName, ScalaJSDefined}
 
 @ScalaJSDefined
-abstract class DefinitionBase[Props, State](jsProps: js.Object)(implicit propsReader: Reader[Props],
-                                                                propsWriter: Writer[Props],
-                                                                stateReader: Reader[State],
-                                                                stateWriter: Writer[State]) extends React.Component(jsProps) {
+abstract class DefinitionBase[Props, State](jsProps: js.Object) extends React.Component(jsProps) {
+  @inline def stateReader: Reader[State] = this.asInstanceOf[js.Dynamic].__proto__.constructor._base._stateReader.asInstanceOf[Reader[State]]
+  @inline def stateWriter: Writer[State] = this.asInstanceOf[js.Dynamic].__proto__.constructor._base._stateWriter.asInstanceOf[Writer[State]]
+  @inline def propsReader: Reader[Props] = this.asInstanceOf[js.Dynamic].__proto__.constructor._base._propsReader.asInstanceOf[Reader[Props]]
+  @inline def propsWriter: Writer[Props] = this.asInstanceOf[js.Dynamic].__proto__.constructor._base._propsWriter.asInstanceOf[Writer[Props]]
+
   def initialState: State
 
   this.asInstanceOf[PrivateComponentClass].stateR = {

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -6,6 +6,8 @@ npmDependencies in Compile += "react" -> "15.6.1"
 
 npmDependencies in Compile += "react-dom" -> "15.6.1"
 
+npmDependencies in Compile += "react-proxy" -> "1.1.8"
+
 webpackConfigFile in fastOptJS := Some(baseDirectory.value / "webpack-fastopt.config.js")
 webpackConfigFile in fullOptJS := Some(baseDirectory.value / "webpack-opt.config.js")
 

--- a/hot/src/main/scala/me/shadaj/slinky/hot/ReactProxy.scala
+++ b/hot/src/main/scala/me/shadaj/slinky/hot/ReactProxy.scala
@@ -1,0 +1,11 @@
+package me.shadaj.slinky.hot
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@JSImport("react-proxy", JSImport.Namespace, "ReactProxy")
+@js.native
+object ReactProxy extends js.Object {
+  def createProxy(componentConstructor: js.Object): js.Object = js.native
+  def getForceUpdate(react: js.Object): js.Function1[js.Object, Unit] = js.native
+}

--- a/hot/src/main/scala/me/shadaj/slinky/hot/package.scala
+++ b/hot/src/main/scala/me/shadaj/slinky/hot/package.scala
@@ -1,25 +1,35 @@
 package me.shadaj.slinky
 
 import me.shadaj.slinky.core.BaseComponentWrapper
+import me.shadaj.slinky.core.facade.React
 
 import scala.scalajs.js
 
 package object hot {
   def initialize(): Unit = {
-    if (js.isUndefined(js.Dynamic.global.previousStates)) {
-      js.Dynamic.global.previousStates = js.Dynamic.literal()
+    if (js.isUndefined(js.Dynamic.global.proxies)) {
+      js.Dynamic.global.proxies = js.Dynamic.literal()
     }
 
-    BaseComponentWrapper.insertGetInitialWrittenStateMiddleware { name =>
-      if (js.isUndefined(js.Dynamic.global.previousStates.selectDynamic(name))) {
-        None
-      } else {
-        Some(js.Dynamic.global.previousStates.selectDynamic(name).apply().asInstanceOf[js.Object])
+    BaseComponentWrapper.insertMiddleware((constructor, component) => {
+      if (js.isUndefined(component.asInstanceOf[js.Dynamic]._hot)) {
+        component.asInstanceOf[js.Dynamic]._hot = true
+
+        if (js.isUndefined(js.Dynamic.global.proxies.selectDynamic(this.getClass.getName))) {
+          println("creating proxy")
+          js.Dynamic.global.proxies.updateDynamic(this.getClass.getName)(ReactProxy.createProxy(constructor))
+        } else {
+          println("updating proxy")
+          val forceUpdate = ReactProxy.getForceUpdate(React)
+          js.Dynamic.global.proxies.selectDynamic(this.getClass.getName)
+            .update(constructor).asInstanceOf[js.Array[js.Object]]
+            .foreach(o => forceUpdate(o))
+        }
       }
-    }
 
-    BaseComponentWrapper.insertWrittenStateMiddleware { (name, getter) =>
-      js.Dynamic.global.previousStates.updateDynamic(name)(getter)
-    }
+      js.Dynamic.global.proxies.selectDynamic(this.getClass.getName).get().asInstanceOf[js.Object]
+    })
+
+    BaseComponentWrapper.enableScalaComponentWriting()
   }
 }

--- a/hot/src/main/scala/me/shadaj/slinky/hot/package.scala
+++ b/hot/src/main/scala/me/shadaj/slinky/hot/package.scala
@@ -16,10 +16,8 @@ package object hot {
         component.asInstanceOf[js.Dynamic]._hot = true
 
         if (js.isUndefined(js.Dynamic.global.proxies.selectDynamic(this.getClass.getName))) {
-          println("creating proxy")
           js.Dynamic.global.proxies.updateDynamic(this.getClass.getName)(ReactProxy.createProxy(constructor))
         } else {
-          println("updating proxy")
           val forceUpdate = ReactProxy.getForceUpdate(React)
           js.Dynamic.global.proxies.selectDynamic(this.getClass.getName)
             .update(constructor).asInstanceOf[js.Array[js.Object]]


### PR DESCRIPTION
The implementation in #48 had a major flaw in that it did not keep track of state tied to each instance of a component. `react-proxy` correctly handles it, so moved back to using that with a fix for loading readers and writers.