### PR TITLE
[WIP] Specific target DOM type for attributes/events, fix #24

### DIFF
--- a/core/src/main/scala/me/shadaj/slinky/core/facade/SyntheticEvent.scala
+++ b/core/src/main/scala/me/shadaj/slinky/core/facade/SyntheticEvent.scala
@@ -5,18 +5,18 @@ import scala.scalajs.js.annotation.JSName
 
 @js.native
 trait SyntheticEvent[T] extends js.Object {
-  val bubbles: Boolean
-  val cancelable: Boolean
-  val currentTarget: T
-  val defaultPrevented: Boolean
-  val eventPhase: Int
-  val isTrusted: Boolean
+  val bubbles: Boolean = js.native
+  val cancelable: Boolean = js.native
+  val currentTarget: T = js.native
+  val defaultPrevented: Boolean = js.native
+  val eventPhase: Int = js.native
+  val isTrusted: Boolean = js.native
 //  val nativeEvent: Event TODO
   def preventDefault(): Unit = js.native
   def isDefaultPrevented: Boolean = js.native
   def stopPropagation(): Unit = js.native
   def isPropagationStopped: Boolean = js.native
-  val target: T
-  val timeStamp: Int
+  val target: T = js.native
+  val timeStamp: Int = js.native
   @JSName("type") val `type`: String = js.native
 }

--- a/core/src/main/scala/me/shadaj/slinky/core/facade/SyntheticEvent.scala
+++ b/core/src/main/scala/me/shadaj/slinky/core/facade/SyntheticEvent.scala
@@ -1,0 +1,22 @@
+package me.shadaj.slinky.core.facade
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSName
+
+@js.native
+trait SyntheticEvent[T] extends js.Object {
+  val bubbles: Boolean
+  val cancelable: Boolean
+  val currentTarget: T
+  val defaultPrevented: Boolean
+  val eventPhase: Int
+  val isTrusted: Boolean
+//  val nativeEvent: Event TODO
+  def preventDefault(): Unit = js.native
+  def isDefaultPrevented: Boolean = js.native
+  def stopPropagation(): Unit = js.native
+  def isPropagationStopped: Boolean = js.native
+  val target: T
+  val timeStamp: Int
+  @JSName("type") val `type`: String = js.native
+}

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -3,14 +3,18 @@ enablePlugins(ScalaJSBundlerPlugin)
 name := "slinky-example"
 
 npmDependencies in Compile += "react" -> "15.6.1"
-
 npmDependencies in Compile += "react-dom" -> "15.6.1"
-
 npmDependencies in Compile += "react-proxy" -> "1.1.8"
+
+npmDevDependencies in Compile += "file-loader" -> "1.1.5"
+npmDevDependencies in Compile += "style-loader" -> "0.19.0"
+npmDevDependencies in Compile += "css-loader" -> "0.28.7"
+npmDevDependencies in Compile += "html-webpack-plugin" -> "2.30.1"
+npmDevDependencies in Compile += "copy-webpack-plugin" -> "4.2.0"
 
 webpackConfigFile in fastOptJS := Some(baseDirectory.value / "webpack-fastopt.config.js")
 webpackConfigFile in fullOptJS := Some(baseDirectory.value / "webpack-opt.config.js")
 
-emitSourceMaps := false
+webpackDevServerExtraArgs in fastOptJS := Seq("--inline", "--hot")
 
-webpackDevServerExtraArgs := Seq("--inline", "--hot")
+webpackBundlingMode in fastOptJS := BundlingMode.LibraryOnly()

--- a/example/hot-launcher.js
+++ b/example/hot-launcher.js
@@ -1,0 +1,5 @@
+require("./slinky-example-fastopt.js").entrypoint.main();
+
+if (module.hot) {
+    module.hot.accept();
+}

--- a/example/opt-launcher.js
+++ b/example/opt-launcher.js
@@ -1,0 +1,1 @@
+require("./slinky-example-opt.js").entrypoint.main();

--- a/example/public/index-fastopt.html
+++ b/example/public/index-fastopt.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="theme-color" content="#000000">
+        <!--
+          manifest.json provides metadata used when your web app is added to the
+          homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+        -->
+        <link rel="manifest" href="manifest.json">
+        <link rel="shortcut icon" href="favicon.ico">
+        <!--
+          Notice the use of %PUBLIC_URL% in the tags above.
+          It will be replaced with the URL of the `public` folder during the build.
+          Only files inside the `public` folder can be referenced from the HTML.
+
+          Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+          work correctly both with client-side routing and a non-root public URL.
+          Learn how to configure a non-root public URL by running `npm run build`.
+        -->
+        <title>React App</title>
+    </head>
+    <body>
+    <noscript>
+        You need to enable JavaScript to run this app.
+    </noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+    -->
+
+    <script src="./slinky-example-fastopt-library.js"></script>
+    <script>
+        var exports = window;
+        exports.require = window["appLibrary"].require;
+        var global = window;
+    </script>
+    <script src="./launcher-library.js"></script>
+    </body>
+</html>

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="theme-color" content="#000000">
+        <!--
+          manifest.json provides metadata used when your web app is added to the
+          homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+        -->
+        <link rel="manifest" href="manifest.json">
+        <link rel="shortcut icon" href="favicon.ico">
+        <!--
+          Notice the use of %PUBLIC_URL% in the tags above.
+          It will be replaced with the URL of the `public` folder during the build.
+          Only files inside the `public` folder can be referenced from the HTML.
+
+          Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+          work correctly both with client-side routing and a non-root public URL.
+          Learn how to configure a non-root public URL by running `npm run build`.
+        -->
+        <title>React App</title>
+    </head>
+    <body>
+    <noscript>
+        You need to enable JavaScript to run this app.
+    </noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+    -->
+    </body>
+</html>

--- a/example/src/main/scala/me/shadaj/slinky/example/Main.scala
+++ b/example/src/main/scala/me/shadaj/slinky/example/Main.scala
@@ -64,8 +64,8 @@ object Main extends JSApp {
         input(
           `type` := "foo",
           onChange := ((e) => {
-            println(e.target.asInstanceOf[html.Input].value)
-            setState(e.target.asInstanceOf[html.Input].value)
+            println(e.target.value)
+            setState(e.target.value)
           }),
           className := "foo",
           style := js.Dynamic.literal(

--- a/example/src/main/scala/me/shadaj/slinky/example/Main.scala
+++ b/example/src/main/scala/me/shadaj/slinky/example/Main.scala
@@ -3,14 +3,10 @@ package me.shadaj.slinky.example
 import me.shadaj.slinky.core._
 import me.shadaj.slinky.core.annotations.react
 import me.shadaj.slinky.core.facade.ReactElement
-
 import me.shadaj.slinky.web.ReactDOM
 import me.shadaj.slinky.web.html._
-
 import me.shadaj.slinky.hot
-
 import me.shadaj.slinky.scalajsreact.Converters._
-
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 
@@ -18,7 +14,9 @@ import scala.scalajs.js
 import scala.scalajs.js.JSApp
 import org.scalajs.dom.{document, html}
 
-object Main extends JSApp {
+import scala.scalajs.js.annotation.JSExportTopLevel
+
+object Main {
   val Hello =
     ScalaComponent.builder[String]("Hello")
       .render_P(name => <.div(
@@ -82,6 +80,7 @@ object Main extends JSApp {
     }
   }
 
+  @JSExportTopLevel("entrypoint.main")
   def main(): Unit = {
     hot.initialize()
     if (js.isUndefined(js.Dynamic.global.reactContainer)) {

--- a/example/src/main/scala/me/shadaj/slinky/example/Main.scala
+++ b/example/src/main/scala/me/shadaj/slinky/example/Main.scala
@@ -65,6 +65,9 @@ object Main {
             println(e.target.value)
             setState(e.target.value)
           }),
+          ref := ((node) => {
+            println(node.value)
+          }),
           className := "foo",
           style := js.Dynamic.literal(
             "color" -> (if (state.contains(" ")) "red" else "green")

--- a/example/webpack-fastopt.config.js
+++ b/example/webpack-fastopt.config.js
@@ -1,9 +1,54 @@
+var path = require("path");
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+var CopyWebpackPlugin = require('copy-webpack-plugin');
+
 module.exports = {
-  "entry": [
-    "../../../../fastopt-launcher.js"
-  ],
-  "output": {
-    "path": ".",
-    "filename": "[name]-bundle.js"
-  }
+    entry: {
+        "slinky-example-fastopt": ["./slinky-example-fastopt-entrypoint.js"],
+        "launcher": ["./hot-launcher.js"]
+    },
+    output: {
+        path: __dirname,
+        filename: "[name]-library.js",
+        library: "appLibrary",
+        libraryTarget: "var"
+    },
+    devtool: "source-map",
+    resolve: {
+        alias: {
+            "resources": path.resolve(__dirname, "../../../../src/main/resources")
+        }
+    },
+    module: {
+        rules: [
+            {
+                test: /\\.css\$/,
+                use: [ 'style-loader', 'css-loader' ]
+            },
+            // "file" loader for svg
+            {
+                test: /\\.svg\$/,
+                use: [
+                    {
+                        loader: 'file-loader',
+                        query: {
+                            name: 'static/media/[name].[hash:8].[ext]'
+                        }
+                    }
+                ]
+            }
+        ],
+        noParse: (content) => {
+          return content.endsWith("-fastopt.js");
+        }
+    },
+    plugins: [
+        new CopyWebpackPlugin([
+            { from: path.resolve(__dirname, "../../../../public") }
+        ]),
+        new HtmlWebpackPlugin({
+            template: path.resolve(__dirname, "../../../../public/index-fastopt.html"),
+            inject: false
+        })
+    ]
 }

--- a/example/webpack-opt.config.js
+++ b/example/webpack-opt.config.js
@@ -1,25 +1,54 @@
-var webpack = require('webpack');
+var webpack = require("webpack");
+var path = require("path");
+
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+var CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
-  "entry": {
-    "simple-react-example-opt": "./opt-launcher.js"
-  },
-  "output": {
-    "path": ".",
-    "filename": "[name]-bundle.js"
-  },
-  "module": {
-    "preLoaders": [{
-      "test": new RegExp("\\.js$"),
-      "loader": "source-map-loader"
-    }]
-  },
-  plugins: [
-      new webpack.DefinePlugin({
-        'process.env': {
-          NODE_ENV: JSON.stringify('production')
+    "entry": {
+        "slinky-example-opt": [ path.resolve(__dirname, "./opt-launcher.js") ]
+    },
+    "output": {
+        "path": path.resolve(__dirname, "../../../../build"),
+        "filename": "[name]-bundle.js"
+    },
+    resolve: {
+        alias: {
+            "resources": path.resolve(__dirname, "../../../../src/main/resources")
         }
-      }),
-      new webpack.optimize.UglifyJsPlugin()
-  ]
+    },
+    module: {
+        rules: [
+            {
+                test: /\\.css\$/,
+                use: [ 'style-loader', 'css-loader' ]
+            },
+            // "file" loader for svg
+            {
+                test: /\\.svg\$/,
+                use: [
+                    {
+                        loader: 'file-loader',
+                        query: {
+                            name: 'static/media/[name].[hash:8].[ext]'
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    plugins: [
+        new CopyWebpackPlugin([
+            { from: path.resolve(__dirname, "../../../../public") }
+        ]),
+        new HtmlWebpackPlugin({
+            template: path.resolve(__dirname, "../../../../public/index.html")
+        }),
+        new webpack.DefinePlugin({
+            'process.env': {
+                NODE_ENV: JSON.stringify('production')
+            }
+        }),
+        new webpack.optimize.UglifyJsPlugin()
+    ]
 }

--- a/generator/src/main/scala/me/shadaj/slinky/generator/Generator.scala
+++ b/generator/src/main/scala/me/shadaj/slinky/generator/Generator.scala
@@ -45,7 +45,6 @@ object Generator extends App {
         }.mkString("\n")
 
         s"""$tagSpecific
-           |def :=(v: ${a.event.get}[org.scalajs.dom.raw.HTMLElement] => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)
            |def :=(v: () => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)""".stripMargin
       } else {
         s"""def :=(v: ${a.attributeType}) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)"""

--- a/generator/src/main/scala/me/shadaj/slinky/generator/Generator.scala
+++ b/generator/src/main/scala/me/shadaj/slinky/generator/Generator.scala
@@ -11,86 +11,92 @@ object Generator extends App {
   val providerName :: out :: pkg :: Nil = args.toList
 
   val outFolder = new File(out)
-  if (!outFolder.exists()) {
-    outFolder.mkdirs()
+  outFolder.mkdirs()
 
-    val extracted = decode[TagsModel](Source.fromFile(providerName).getLines().mkString("\n")).right.get
+  val extracted = decode[TagsModel](Source.fromFile(providerName).getLines().mkString("\n")).right.get
 
-    val allSymbols = extracted.attributes.foldLeft(extracted.tags.map(t => Utils.identifierFor(t.tagName) -> (Some(t): Option[Tag], None: Option[Attribute])).toSet) { case (symbols, attr) =>
-      symbols.find(_._1 == Utils.identifierFor(attr.attributeName)) match {
-        case Some(o@(_, (tags, None))) =>
-          symbols - o + ((Utils.identifierFor(attr.attributeName), (tags, Some(attr))))
-        case None =>
-          symbols + ((Utils.identifierFor(attr.attributeName), (None, Some(attr))))
+  val allSymbols = extracted.attributes.foldLeft(extracted.tags.map(t => Utils.identifierFor(t.tagName) -> (Some(t): Option[Tag], None: Option[Attribute])).toSet) { case (symbols, attr) =>
+    symbols.find(_._1 == Utils.identifierFor(attr.attributeName)) match {
+      case Some(o@(_, (tags, None))) =>
+        symbols - o + ((Utils.identifierFor(attr.attributeName), (tags, Some(attr))))
+      case None =>
+        symbols + ((Utils.identifierFor(attr.attributeName), (None, Some(attr))))
+    }
+  }
+
+  allSymbols.foreach { case (symbol, (tags, attrs)) =>
+    val symbolWithoutEscape = if (symbol.startsWith("`")) symbol.tail.init else symbol
+
+    val tagsGen = tags.map { t =>
+      s"""/**
+         | * ${t.docLines.map(_.replace("*", "&#47;")).mkString("\n * ")}
+         | */
+         |def apply(mods: TagMod[tag.type]*) = new TagComponent[tag.type]("${t.tagName}").apply(mods: _*)""".stripMargin
+    }
+
+    val attrsGen = attrs.toList.flatMap { a =>
+      val base = if (a.event.isDefined) {
+        val targetTags = a.compatibleTags.getOrElse(extracted.tags.map(_.tagName)).map { t =>
+          extracted.tags.find(_.tagName == t).get
+        }
+
+        val tagSpecific = targetTags.map { t =>
+          s"""
+              def :=(v: SyntheticEvent[${t.scalajsDomType}] => Unit)(implicit _imp: ${Utils.identifierFor(t.tagName)}.tagType.type): TagMod[${Utils.identifierFor(t.tagName)}.tag.type] = new AttrPair[${Utils.identifierFor(t.tagName)}.tag.type]("${a.attributeName}", v)
+           """.stripMargin
+        }.mkString("\n")
+
+        s"""$tagSpecific
+           |def :=(v: () => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)
+         """.stripMargin
+      } else {
+        s"""def :=(v: ${a.attributeType}) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)"""
+      }
+
+      if (a.withDash) {
+        Seq(
+          base,
+          s"""class WithDash(val sub: String) { def :=(v: ${a.attributeType}) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}-" + sub, v) }
+             |def -(sub: String) = new WithDash(sub)""".stripMargin
+        )
+      } else Seq(base)
+    }
+
+    val attrToTagImplicits = attrs.toList.flatMap { a =>
+      a.compatibleTags.getOrElse(extracted.tags.map(_.tagName)).map { t =>
+        s"""implicit def to${t}Applied(pair: AttrPair[_${symbolWithoutEscape}_attr.type]) = pair.asInstanceOf[AttrPair[${Utils.identifierFor(t)}.tag.type]]"""
       }
     }
 
-    allSymbols.foreach { case (symbol, (tags, attrs)) =>
-      val symbolWithoutEscape = if (symbol.startsWith("`")) symbol.tail.init else symbol
+    val symbolExtends = if (attrs.isDefined && attrs.get.attributeType == "Boolean") {
+      s"""extends AttrPair[_${symbolWithoutEscape}_attr.type]("${attrs.get.attributeName}", true)"""
+    } else ""
 
-      val tagsGen = tags.map { t =>
-        s"""/**
-           | * ${t.docLines.map(_.replace("*", "&#47;")).mkString("\n * ")}
-           | */
-           |def apply(mods: TagMod[tag.type]*) = new TagComponent[tag.type]("${t.tagName}").apply(mods: _*)""".stripMargin
-      }
+    val out = new PrintWriter(new File(outFolder.getAbsolutePath + "/" + symbol + ".scala"))
 
-      val attrsGen = attrs.toList.flatMap { a =>
-        val base = if (a.attributeType == "EventHandler") {
-          s"""def :=(v: org.scalajs.dom.Event => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)
-             |def :=(v: () => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)
-           """.stripMargin
-        } else if (a.attributeType == "MouseEventHandler") {
-          s"""def :=(v: org.scalajs.dom.MouseEvent => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)
-             |def :=(v: () => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)
-           """.stripMargin
-        } else {
-          s"""def :=(v: ${a.attributeType}) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)"""
-        }
+    out.println(
+      s"""package ${pkg}
+         |
+         |import me.shadaj.slinky.core.{AttrPair, TagComponent, TagMod, TagElement}
+         |import me.shadaj.slinky.core.facade.SyntheticEvent
+         |import scala.scalajs.js
+         |import scala.language.implicitConversions
+         |
+         |/**
+         | * ${attrs.map(_.docLines.map(_.replace("*", "&#47;")).mkString("\n * ")).getOrElse("")}
+         | */
+         |object $symbol $symbolExtends {
+         |object tag extends TagElement
+         |implicit object tagType
+         |${tagsGen.mkString("\n")}
+         |${attrsGen.mkString("\n")}
+         |}
+         |
+         |object _${symbolWithoutEscape}_attr {
+         |${attrToTagImplicits.mkString("\n")}
+         |}""".stripMargin
+    )
 
-        if (a.withDash) {
-          Seq(
-            base,
-            s"""class WithDash(val sub: String) { def :=(v: ${a.attributeType}) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}-" + sub, v) }
-               |def -(sub: String) = new WithDash(sub)""".stripMargin
-          )
-        } else Seq(base)
-      }
-
-      val attrToTagImplicits = attrs.toList.flatMap { a =>
-        a.compatibleTags.getOrElse(extracted.tags.map(_.tagName)).map { t =>
-          s"""implicit def to${t}Applied(pair: AttrPair[_${symbolWithoutEscape}_attr.type]) = pair.asInstanceOf[AttrPair[${Utils.identifierFor(t)}.tag.type]]"""
-        }
-      }
-
-      val symbolExtends = if (attrs.isDefined && attrs.get.attributeType == "Boolean") {
-        s"""extends AttrPair[_${symbolWithoutEscape}_attr.type]("${attrs.get.attributeName}", true)"""
-      } else ""
-
-      val out = new PrintWriter(new File(outFolder.getAbsolutePath + "/" + symbol + ".scala"))
-
-      out.println(
-        s"""package ${pkg}
-           |
-           |import me.shadaj.slinky.core.{AttrPair, TagComponent, TagMod, TagElement}
-           |import scala.scalajs.js
-           |import scala.language.implicitConversions
-           |
-           |/**
-           | * ${attrs.map(_.docLines.map(_.replace("*", "&#47;")).mkString("\n * ")).getOrElse("")}
-           | */
-           |object $symbol $symbolExtends {
-           |object tag extends TagElement
-           |${tagsGen.mkString("\n")}
-           |${attrsGen.mkString("\n")}
-           |}
-           |
-           |object _${symbolWithoutEscape}_attr {
-           |${attrToTagImplicits.mkString("\n")}
-           |}""".stripMargin
-      )
-
-      out.close()
-    }
+    out.close()
   }
 }

--- a/generator/src/main/scala/me/shadaj/slinky/generator/Generator.scala
+++ b/generator/src/main/scala/me/shadaj/slinky/generator/Generator.scala
@@ -46,6 +46,14 @@ object Generator extends App {
 
         s"""$tagSpecific
            |def :=(v: () => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)""".stripMargin
+      } else if (a.attributeName == "ref") {
+        val targetTags = a.compatibleTags.getOrElse(extracted.tags.map(_.tagName)).map { t =>
+          extracted.tags.find(_.tagName == t).get
+        }
+
+        targetTags.map { t =>
+          s"""def :=(v: ${t.scalajsDomType} => Unit)(implicit _imp: ${Utils.identifierFor(t.tagName)}.tagType.type): TagMod[${Utils.identifierFor(t.tagName)}.tag.type] = new AttrPair[${Utils.identifierFor(t.tagName)}.tag.type]("${a.attributeName}", v)"""
+        }.mkString("\n")
       } else {
         s"""def :=(v: ${a.attributeType}) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)"""
       }

--- a/generator/src/main/scala/me/shadaj/slinky/generator/Generator.scala
+++ b/generator/src/main/scala/me/shadaj/slinky/generator/Generator.scala
@@ -41,14 +41,12 @@ object Generator extends App {
         }
 
         val tagSpecific = targetTags.map { t =>
-          s"""
-              def :=(v: SyntheticEvent[${t.scalajsDomType}] => Unit)(implicit _imp: ${Utils.identifierFor(t.tagName)}.tagType.type): TagMod[${Utils.identifierFor(t.tagName)}.tag.type] = new AttrPair[${Utils.identifierFor(t.tagName)}.tag.type]("${a.attributeName}", v)
-           """.stripMargin
+          s"""def :=(v: ${a.event.get}[${t.scalajsDomType}] => Unit)(implicit _imp: ${Utils.identifierFor(t.tagName)}.tagType.type): TagMod[${Utils.identifierFor(t.tagName)}.tag.type] = new AttrPair[${Utils.identifierFor(t.tagName)}.tag.type]("${a.attributeName}", v)"""
         }.mkString("\n")
 
         s"""$tagSpecific
-           |def :=(v: () => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)
-         """.stripMargin
+           |def :=(v: ${a.event.get}[org.scalajs.dom.raw.HTMLElement] => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)
+           |def :=(v: () => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)""".stripMargin
       } else {
         s"""def :=(v: ${a.attributeType}) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)"""
       }

--- a/generator/src/main/scala/me/shadaj/slinky/generator/MDN.scala
+++ b/generator/src/main/scala/me/shadaj/slinky/generator/MDN.scala
@@ -167,7 +167,7 @@ object MDN extends TagsProvider {
   def extract: (Seq[Tag], Seq[Attribute]) = {
     val tagsWithAttributes = tags.map { n =>
       val extracted = htmlElement(n)
-      (Tag(n, extracted._1.split('\n')), extracted._2)
+      (Tag(n, "", extracted._1.split('\n')), extracted._2)
     }
 
     val attrs = tagsWithAttributes.flatMap(v => v._2.map(t => (v._1, t._1, t._2)))

--- a/generator/src/main/scala/me/shadaj/slinky/generator/Model.scala
+++ b/generator/src/main/scala/me/shadaj/slinky/generator/Model.scala
@@ -12,10 +12,18 @@ object Utils {
 
 case class TagsModel(tags: Seq[Tag], attributes: Seq[Attribute])
 
-case class Tag(tagName: String, docLines: Seq[String])
+case class Tag(tagName: String, scalajsDomType: String, docLines: Seq[String])
 
 case class Attribute(attributeName: String,
                      attributeType: String,
                      docLines: Seq[String],
                      compatibleTags: Option[Seq[String]],
-                     withDash: Boolean) /* tag, identifier, doc */
+                     withDash: Boolean) /* tag, identifier, doc */ {
+  lazy val event: Option[String] = {
+    if (attributeType.endsWith("EventHandler")) {
+      Some(attributeType.dropRight("Handler".length))
+    } else {
+      None
+    }
+  }
+}

--- a/generator/src/main/scala/me/shadaj/slinky/generator/Model.scala
+++ b/generator/src/main/scala/me/shadaj/slinky/generator/Model.scala
@@ -20,8 +20,8 @@ case class Attribute(attributeName: String,
                      compatibleTags: Option[Seq[String]],
                      withDash: Boolean) /* tag, identifier, doc */ {
   lazy val event: Option[String] = {
-    if (attributeType.endsWith("EventHandler")) {
-      Some(attributeType.dropRight("Handler".length))
+    if (attributeType.contains("Synthetic")) {
+      Some(attributeType)
     } else {
       None
     }

--- a/generator/src/main/scala/me/shadaj/slinky/generator/SVG.scala
+++ b/generator/src/main/scala/me/shadaj/slinky/generator/SVG.scala
@@ -80,7 +80,7 @@ object SVG extends TagsProvider {
       .stripMargin.split('\n').flatMap(_.split(' ')).toSet ++ MDN.supportedAttributes
 
   def extract: (Seq[Tag], Seq[Attribute]) = {
-    val allTags = supportedTags.map(t => Tag(t, Seq.empty))
+    val allTags = supportedTags.map(t => Tag(t, "org.scalajs.dom.raw.HTMLElement", Seq.empty))
 
     val attributes = allAttributes.map(SVGToJSMapping.convert).flatMap { converted =>
       if (supportedAttributes.contains(converted.name)) {

--- a/tests/src/test/scala/me/shadaj/slinky/core/TagTest.scala
+++ b/tests/src/test/scala/me/shadaj/slinky/core/TagTest.scala
@@ -6,7 +6,8 @@ import me.shadaj.slinky.web.html._
 
 import scala.scalajs.js
 
-import org.scalajs.dom.MouseEvent
+import me.shadaj.slinky.web.SyntheticMouseEvent
+import org.scalajs.dom.raw.HTMLElement
 
 class TagTest extends FunSuite {
   test("Fails compilation when an incompatible attr is provided") {
@@ -43,6 +44,6 @@ class TagTest extends FunSuite {
   }
 
   test("Mouse events can be given a function taking a MouseEvent") {
-    assertCompiles("div(onMouseOver := ((v: MouseEvent) => {}))")
+    assertCompiles("div(onMouseOver := ((v: SyntheticMouseEvent[HTMLElement]) => {}))")
   }
 }

--- a/web/html.json
+++ b/web/html.json
@@ -2,672 +2,784 @@
   "tags" : [
     {
       "tagName" : "a",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "<span class=\"seoSummary\">The <strong>HTML <code>&lt;a&gt;</code> element</strong> (or <em>anchor</em> element) creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL.</span>"
       ]
     },
     {
       "tagName" : "abbr",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;abbr&gt;</code> element</strong> represents an abbreviation and optionally provides a full description for it. If present, the <code><a href=\"/en-US/docs/Web/HTML/Global_attributes#attr-title\">title</a></code> attribute must contain this full description and nothing else."
       ]
     },
     {
       "tagName" : "address",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "<span class=\"seoSummary\">The <strong>HTML&nbsp;<code>&lt;address&gt;</code> element</strong> supplies contact information for its nearest <a title=\"The HTML <article> element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry.\" href=\"/en-US/docs/Web/HTML/Element/article\"><code>&lt;article&gt;</code></a> or <a title=\"The HTML <body> Element represents the content of an HTML&nbsp;document. There can be only one <body> element in a document.\" href=\"/en-US/docs/Web/HTML/Element/body\"><code>&lt;body&gt;</code></a> ancestor; in the latter case, it applies to the whole document.</span>"
       ]
     },
     {
       "tagName" : "area",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;area&gt;</code> element</strong> defines a hot-spot region on an image, and optionally associates it with a <a title=\"hypertext link: Hyperlinks connect webpages or data items to one another. In HTML, <a> elements define hyperlinks from a spot on a webpage (like a text string or image) to another spot on some other webpage (or even on the same page).\" class=\"glossaryLink\" href=\"/en-US/docs/Glossary/Hyperlink\">hypertext link</a>. This element is used only within a <a title=\"The HTML <map> element is used with <area> elements to define an image map (a clickable link area).\" href=\"/en-US/docs/Web/HTML/Element/map\"><code>&lt;map&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "article",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;article&gt;</code> element</strong> represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry."
       ]
     },
     {
       "tagName" : "aside",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;aside&gt;</code> element</strong> represents a section of a document with content connected tangentially to the main content of the document (often presented as a sidebar)."
       ]
     },
     {
       "tagName" : "audio",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "<span class=\"seoSummary\">The <strong>HTML <code>&lt;audio&gt;</code> element</strong> is used to embed sound content in documents. It may contain one or more audio sources, represented using the <code>src</code> attribute or the <a title=\"The HTML <source> element specifies multiple media resources for either the <picture>, the <audio> or the <video> element. It is an empty element. It is commonly used to serve the same media content in multiple formats supported by different browsers.\" href=\"/en-US/docs/Web/HTML/Element/source\"><code>&lt;source&gt;</code></a> element:&nbsp;the browser will choose the most suitable one. It can also be the destination for streamed media, using a <a title=\"The MediaStream interface represents a stream of media content. A stream consists of several tracks such as&nbsp;video or audio tracks. Each track is specified as an instance of MediaStreamTrack.\" href=\"/en-US/docs/Web/API/MediaStream\"><code>MediaStream</code></a>.</span>"
       ]
     },
     {
       "tagName" : "b",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;b&gt;</code> element</strong> represents a span of text stylistically different from normal text, without conveying any special importance or relevance, and that is typically rendered in boldface."
       ]
     },
     {
       "tagName" : "base",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;base&gt;</code> element</strong> specifies the base URL to use for all relative URLs contained within a document. There can be only one <code>&lt;base&gt;</code> element in a document.&nbsp;"
       ]
     },
     {
       "tagName" : "bdi",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;bdi&gt;</code> element</strong> (<em>bidirectional isolation</em>) isolates a span of text that might be formatted in a different direction from other text outside it."
       ]
     },
     {
       "tagName" : "bdo",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;bdo&gt;</code> element</strong> (<em>bidirectional override</em>) is used to override the current directionality of text. It causes the directionality of the characters to be ignored in favor of the specified directionality."
       ]
     },
     {
       "tagName" : "big",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The HTML Big Element (<code>&lt;big&gt;</code>)&nbsp;makes the text <em>font size</em> one size bigger (for example, from small to medium, or from large to x-large) up to the browser's maximum font size."
       ]
     },
     {
       "tagName" : "blockquote",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;blockquote&gt;</code> Element</strong> (or <em>HTML Block Quotation Element</em>) indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see <a href=\"/en-US/docs/HTML/Element/blockquote#Notes\">Notes</a> for how to change it). A URL for the source of the quotation may be given using the <strong>cite</strong> attribute, while a text representation of the source can be given using the <a title=\"The HTML <cite> element represents a reference to a creative work. It must include the title of a work or a URL reference, which may be in an abbreviated form according to the conventions used for the addition of citation metadata.\" href=\"/en-US/docs/Web/HTML/Element/cite\"><code>&lt;cite&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "body",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;body&gt;</code> Element</strong> represents the content of an HTML&nbsp;document. There can be only one <code>&lt;body&gt;</code> element in a document."
       ]
     },
     {
       "tagName" : "br",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;br&gt;</code> element</strong> produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant."
       ]
     },
     {
       "tagName" : "button",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;button&gt;</code> element</strong> represents a clickable button."
       ]
     },
     {
       "tagName" : "canvas",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "Use the <strong>HTML <code>&lt;canvas&gt;</code> element</strong> with the <a href=\"/en-US/docs/Web/API/Canvas_API\">canvas scripting API </a>to draw graphics and animations."
       ]
     },
     {
       "tagName" : "caption",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;caption&gt;</code> element</strong> represents the title of a table. Though it is always the first descendant of a <a title=\"The HTML <table> element represents tabular data — that is, information expressed via a two-dimensional data table.\" href=\"/en-US/docs/Web/HTML/Element/table\"><code>&lt;table&gt;</code></a>, its styling, using CSS, may place it elsewhere, relative to the table."
       ]
     },
     {
       "tagName" : "cite",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML &lt;cite&gt; element</strong> represents a reference to a creative work. It must include the title of a work or a URL reference, which may be in an abbreviated form according to the conventions used for the addition of citation metadata."
       ]
     },
     {
       "tagName" : "code",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;code&gt;</code> element</strong> represents a fragment of computer code. By default, it is displayed in the browser's default monospace font."
       ]
     },
     {
       "tagName" : "col",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;col&gt;</code> element</strong> defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a <a title=\"The HTML <colgroup> element defines a group of columns within a table.\" href=\"/en-US/docs/Web/HTML/Element/colgroup\"><code>&lt;colgroup&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "colgroup",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;colgroup&gt;</code> element</strong> defines a group of columns within a table."
       ]
     },
     {
       "tagName" : "data",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;data&gt;</code> element</strong> links a given content with a machine-readable translation. If the content is time- or date-related, the <a title=\"The HTML <time> element represents either a time on a 24-hour clock or a precise date in the Gregorian calendar (with optional time and timezone information).\" href=\"/en-US/docs/Web/HTML/Element/time\"><code>&lt;time&gt;</code></a> element must be used."
       ]
     },
     {
       "tagName" : "datalist",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;datalist&gt;</code> element</strong> contains a set of <a title=\"The HTML <option> element is used to define an item contained in a <select>, an <optgroup>, or a <datalist>&nbsp;element. As such,&nbsp;<option>&nbsp;can represent menu items in popups and other lists of items in an HTML document.\" href=\"/en-US/docs/Web/HTML/Element/option\"><code>&lt;option&gt;</code></a> elements that represent the values available for other controls."
       ]
     },
     {
       "tagName" : "dd",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The&nbsp;<strong>HTML <code>&lt;dd&gt;</code> element</strong> indicates the description of a term in a description list (<a title=\"The HTML <dl>&nbsp;element represents a description list.&nbsp;The element encloses a list of groups of terms and descriptions. Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs).\" href=\"/en-US/docs/Web/HTML/Element/dl\"><code>&lt;dl&gt;</code></a>)."
       ]
     },
     {
       "tagName" : "del",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;del&gt;</code> element</strong> represents a range of text that has been deleted from a document. This element is often (but need not be) rendered with strike-through text."
       ]
     },
     {
       "tagName" : "details",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;details&gt;</code> element</strong> is used as a disclosure widget from which the user can retrieve additional information."
       ]
     },
     {
       "tagName" : "dfn",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML &lt;dfn&gt; element</strong> represents the defining instance of a term."
       ]
     },
     {
       "tagName" : "dialog",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;dialog&gt;</code> element</strong> represents a dialog box or other interactive component, such as an inspector or window."
       ]
     },
     {
       "tagName" : "div",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;div&gt;</code> element</strong> is the generic container for flow content and does not inherently represent anything. Use it to group elements for purposes such as styling (using the <code><a href=\"/en-US/docs/Web/HTML/Global_attributes#attr-class\">class</a></code> or <code><a href=\"/en-US/docs/Web/HTML/Global_attributes#attr-id\">id</a></code> attributes), marking a section of a document in a different language (using the <code><a href=\"/en-US/docs/Web/HTML/Global_attributes#attr-lang\">lang</a></code> attribute), and so on."
       ]
     },
     {
       "tagName" : "dl",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;dl&gt;</code>&nbsp;</strong>element represents a description list.<strong>&nbsp;</strong>The element encloses a list of groups of terms and descriptions. Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs)."
       ]
     },
     {
       "tagName" : "dt",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;dt&gt;</code> element</strong> identifies a term in a description list. This element can occur only as a child element of a <a title=\"The HTML <dl>&nbsp;element represents a description list.&nbsp;The element encloses a list of groups of terms and descriptions. Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs).\" href=\"/en-US/docs/Web/HTML/Element/dl\"><code>&lt;dl&gt;</code></a>. It is usually followed by a <a title=\"The&nbsp;HTML <dd> element indicates the description of a term in a description list (<dl>).\" href=\"/en-US/docs/Web/HTML/Element/dd\"><code>&lt;dd&gt;</code></a> element; however, multiple <code>&lt;dt&gt;</code> elements in a row indicate several terms that are all defined by the immediate next <a title=\"The&nbsp;HTML <dd> element indicates the description of a term in a description list (<dl>).\" href=\"/en-US/docs/Web/HTML/Element/dd\"><code>&lt;dd&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "em",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;em&gt;</code> element</strong>&nbsp;marks text that has stress emphasis. The <code>&lt;em&gt;</code> element can be nested, with each level of nesting indicating a greater degree of emphasis."
       ]
     },
     {
       "tagName" : "embed",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;embed&gt;</code> element</strong> represents an integration point for an external application or interactive content (in other words, a plug-in)."
       ]
     },
     {
       "tagName" : "fieldset",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;fieldset&gt;</code> element</strong> is used to group several controls as well as labels (<a href=\"/en-US/docs/Web/HTML/Element/label\" title=\"The HTML <label> element represents a caption for an item in a user interface.\"><code>&lt;label&gt;</code></a>) within a web form."
       ]
     },
     {
       "tagName" : "figcaption",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;figcaption&gt;</code> element</strong> represents a caption or a legend associated with a figure or an illustration described by the rest of the data of the <a title=\"The HTML <figure> element represents self-contained content, frequently with a caption (<figcaption>), and is typically referenced as a single unit.\" href=\"/en-US/docs/Web/HTML/Element/figure\"><code>&lt;figure&gt;</code></a> element which is its immediate ancestor."
       ]
     },
     {
       "tagName" : "figure",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;figure&gt;</code> element</strong> represents self-contained content, frequently with a caption (<a title=\"The HTML <figcaption> element represents a caption or a legend associated with a figure or an illustration described by the rest of the data of the <figure> element which is its immediate ancestor.\" href=\"/en-US/docs/Web/HTML/Element/figcaption\"><code>&lt;figcaption&gt;</code></a>), and is typically referenced as a single unit."
       ]
     },
     {
       "tagName" : "footer",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The<strong> HTML <code>&lt;footer&gt;</code> element</strong> represents a footer for its nearest <a href=\"/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document#Defining_Sections_in_HTML5\">sectioning content</a> or <a title=\"Sections and Outlines of an HTML5 document#Sectioning root\" href=\"/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document#Sectioning_root\">sectioning root</a> element. A footer typically contains information about the author of the section, copyright data or links to related documents."
       ]
     },
     {
       "tagName" : "form",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;form&gt;</code> element</strong> represents a document section that contains interactive controls to submit information to a web server."
       ]
     },
     {
       "tagName" : "h1",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "A header element"
       ]
     },
     {
       "tagName" : "h2",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "A header element"
       ]
     },
     {
       "tagName" : "h3",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "A header element"
       ]
     },
     {
       "tagName" : "h4",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "A header element"
       ]
     },
     {
       "tagName" : "h5",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "A header element"
       ]
     },
     {
       "tagName" : "h6",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "A header element"
       ]
     },
     {
       "tagName" : "head",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;head&gt;</code> element</strong> provides general information (metadata) about the document, including its title and links to its&nbsp;scripts and style sheets."
       ]
     },
     {
       "tagName" : "header",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;header&gt;</code> element</strong> represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also other elements like a logo, a search form, an author name, and so on."
       ]
     },
     {
       "tagName" : "hr",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;hr&gt;</code> element</strong> represents a thematic break between paragraph-level elements (for example, a change of scene in a story, or a shift of topic with a section). In previous versions of HTML, it represented a horizontal rule. It may still be displayed as a horizontal rule in visual browsers, but is now defined in semantic terms, rather than presentational terms."
       ]
     },
     {
       "tagName" : "html",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;html&gt;</code> element</strong> represents the root (top-level element) of an HTML document, so it is also referred to as the <em>root element</em>. All other elements must be descendants of this element."
       ]
     },
     {
       "tagName" : "i",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;i&gt;</code> element</strong> represents a range of text that is set off from the normal text for some reason, for example, technical terms, foreign language phrases, or fictional character thoughts. It is typically displayed in italic type."
       ]
     },
     {
       "tagName" : "iframe",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;iframe&gt;</code>&nbsp;element</strong>&nbsp;represents a nested browsing context, effectively embedding another HTML page into the current page. In HTML 4.01, a document may contain a <code>head</code> and a <code>body</code> or a <code>head</code> and a <code>frameset</code>, but not both a <code>body</code> and a <code>frameset</code>. However, an <code>&lt;iframe&gt;</code> can be used within a normal document body. Each browsing context has its own session history and active document. The browsing context that contains the embedded content is called the <dfn>parent</dfn> browsing context. The <dfn>top-level</dfn> browsing context (which has no parent) is typically the browser window."
       ]
     },
     {
       "tagName" : "img",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;img&gt;</code> element</strong> represents an image in the document."
       ]
     },
     {
       "tagName" : "input",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLInputElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;input&gt;</code> element</strong> is used to create interactive controls for web-based forms in order to accept data from the user."
       ]
     },
     {
       "tagName" : "ins",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;ins&gt;</code> element</strong> represents a range of text that has been added to a document."
       ]
     },
     {
       "tagName" : "kbd",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;kbd&gt;</code> element</strong> represents user input and produces an inline element displayed in the browser's default monospace font."
       ]
     },
     {
       "tagName" : "keygen",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The HTML <code>&lt;keygen&gt;</code> element exists to facilitate generation of key material, and submission of the public key as part of an <a href=\"/en-US/docs/Web/Guide/HTML/Forms\">HTML form</a>. This mechanism is designed for use with Web-based certificate management systems. It is expected that the <code>&lt;keygen&gt;</code> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate."
       ]
     },
     {
       "tagName" : "label",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;label&gt;</code> element</strong> represents a caption for an item in a user interface."
       ]
     },
     {
       "tagName" : "legend",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;legend&gt;</code> element</strong> represents a caption for the content of its parent <a title=\"The HTML <fieldset> element is used to group several controls as well as labels (<label>) within a web form.\" href=\"/en-US/docs/Web/HTML/Element/fieldset\"><code>&lt;fieldset&gt;</code></a>."
       ]
     },
     {
       "tagName" : "li",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;li&gt;</code> element</strong> is used to represent an item in a list. It must be contained in a parent element: an ordered list (<a title=\"The HTML <ol> element represents an ordered list of items, typically rendered as a numbered list.\" href=\"/en-US/docs/Web/HTML/Element/ol\"><code>&lt;ol&gt;</code></a>), an unordered list (<a title=\"The HTML <ul> element represents an unordered list of items, typically rendered as a bulleted list.\" href=\"/en-US/docs/Web/HTML/Element/ul\"><code>&lt;ul&gt;</code></a>), or a menu (<a title=\"The HTML <menu> element represents a group of commands that a user can perform or activate. This includes both list menus, which might appear across the top of a screen, as well as context menus, such as those that might appear underneath a button after it has been clicked.\" href=\"/en-US/docs/Web/HTML/Element/menu\"><code>&lt;menu&gt;</code></a>). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter."
       ]
     },
     {
       "tagName" : "link",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;link&gt;</code> element</strong> specifies relationships between the current document and an external resource. Possible uses for this element include defining a relational framework for navigation. This element is most used to link to <a title=\"Cascading Style Sheets\" href=\"/en-US/docs/Glossary/CSS\">style sheets</a>."
       ]
     },
     {
       "tagName" : "main",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;main&gt;</code> element</strong> represents the main content of&nbsp;the <a title=\"The HTML <body> Element represents the content of an HTML&nbsp;document. There can be only one <body> element in a document.\" href=\"/en-US/docs/Web/HTML/Element/body\"><code>&lt;body&gt;</code></a> of a document, portion of a document, or application. The main content area consists of content that is directly related to, or expands upon the central topic of, a document or the central functionality of an application."
       ]
     },
     {
       "tagName" : "map",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;map&gt;</code> element</strong> is used with <a title=\"The HTML <area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a <map> element.\" href=\"/en-US/docs/Web/HTML/Element/area\"><code>&lt;area&gt;</code></a> elements to define an image map (a clickable link area)."
       ]
     },
     {
       "tagName" : "mark",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "<span class=\"seoSummary\">The <strong>HTML <code>&lt;mark&gt;</code> element</strong> represents highlighted text, i.e., a run of text marked for reference purpose, due to its <em>relevance</em> in a particular context.</span> For example it can be used in a page showing search results to highlight every instance of the searched-for word."
       ]
     },
     {
       "tagName" : "menu",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;menu&gt;</code> element</strong> represents a group of commands that a user can perform or activate. This includes both list menus, which might appear across the top of a screen, as well as context menus, such as those that might appear underneath a button after it has been clicked."
       ]
     },
     {
       "tagName" : "menuitem",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;menuitem&gt;</code> element</strong> represents a command that a user is able to invoke through a popup menu. This includes context menus, as well as menus that might be attached to a menu button."
       ]
     },
     {
       "tagName" : "meta",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;meta&gt;</code> element</strong> represents <a title=\"metadata: Metadata is — in its very simplest definition — data that describes data. For example, an HTML document is data, but HTML can also contain metadata in its <head> element that describes the document — for example who wrote it, and its summary.\" class=\"glossaryLink\" href=\"/en-US/docs/Glossary/Metadata\">metadata</a> that cannot be represented by other HTML meta-related elements, like <a title=\"The HTML <base> element specifies the base URL to use for all relative URLs contained within a document. There can be only one <base> element in a document.\" href=\"/en-US/docs/Web/HTML/Element/base\"><code>&lt;base&gt;</code></a>, <a title=\"The HTML <link> element specifies relationships between the current document and an external resource. Possible uses for this element include defining a relational framework for navigation. This element is most used to link to style sheets.\" href=\"/en-US/docs/Web/HTML/Element/link\"><code>&lt;link&gt;</code></a>, <a title=\"The HTML <script> element is used to embed or reference an executable script.\" href=\"/en-US/docs/Web/HTML/Element/script\"><code>&lt;script&gt;</code></a>, <a title=\"The HTML <style> element contains style information for a document, or part of a document. By default, the style instructions written inside that element are expected to be CSS.\" href=\"/en-US/docs/Web/HTML/Element/style\"><code>&lt;style&gt;</code></a> or <a title=\"The HTML <title> element defines the title of the document, shown in a browser's title bar or on the page's tab. It can only contain text, and any contained tags are ignored.\" href=\"/en-US/docs/Web/HTML/Element/title\"><code>&lt;title&gt;</code></a>."
       ]
     },
     {
       "tagName" : "meter",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;meter&gt;</code> element</strong> represents either a scalar value within a known range or a fractional value."
       ]
     },
     {
       "tagName" : "nav",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "<span class=\"seoSummary\">The <strong>HTML <code>&lt;nav&gt;</code> element</strong> represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes.</span>"
       ]
     },
     {
       "tagName" : "noscript",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;noscript&gt;</code> element</strong> defines a section of HTML to be inserted if a script type on the page is unsupported or if scripting is currently turned off in the browser."
       ]
     },
     {
       "tagName" : "object",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;object&gt;</code> element</strong> represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."
       ]
     },
     {
       "tagName" : "ol",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;ol&gt;</code> element</strong> represents an ordered list of items, typically rendered as a numbered list."
       ]
     },
     {
       "tagName" : "optgroup",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;optgroup&gt;</code> element</strong> creates a grouping of options within a <a title=\"The HTML <select> element represents a control that provides a menu of options:\" href=\"/en-US/docs/Web/HTML/Element/select\"><code>&lt;select&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "option",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "<span class=\"seoSummary\">The <strong>HTML <code>&lt;option&gt;</code> element</strong> is used to define an item contained in a <a title=\"The HTML <select> element represents a control that provides a menu of options:\" href=\"/en-US/docs/Web/HTML/Element/select\"><code>&lt;select&gt;</code></a>, an <a title=\"The HTML <optgroup> element creates a grouping of options within a <select> element.\" href=\"/en-US/docs/Web/HTML/Element/optgroup\"><code>&lt;optgroup&gt;</code></a>, or a <a title=\"The HTML <datalist> element contains a set of <option> elements that represent the values available for other controls.\" href=\"/en-US/docs/Web/HTML/Element/datalist\"><code>&lt;datalist&gt;</code></a>&nbsp;element. As such,&nbsp;<code>&lt;option&gt;</code>&nbsp;can represent menu items in popups and other lists of items in an HTML document.</span>"
       ]
     },
     {
       "tagName" : "output",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;output&gt;</code> element</strong> represents the result of a calculation or user action."
       ]
     },
     {
       "tagName" : "p",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "<span class=\"seoSummary\">The <strong>HTML <code>&lt;p&gt;</code> element</strong> represents a paragraph of text.</span> Paragraphs are usually represented in visual media as blocks of text that are separated from adjacent blocks by vertical blank space and/or first-line indentation.&nbsp;Paragraphs are <a href=\"/en-US/docs/Web/HTML/Block-level_elements\">block-level elements</a>."
       ]
     },
     {
       "tagName" : "param",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;param&gt;</code> element</strong> defines parameters for an <a title=\"The HTML <object> element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin.\" href=\"/en-US/docs/Web/HTML/Element/object\"><code>&lt;object&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "picture",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;picture&gt;</code> element</strong> is a container used to specify multiple <a title=\"The HTML <source> element specifies multiple media resources for either the <picture>, the <audio> or the <video> element. It is an empty element. It is commonly used to serve the same media content in multiple formats supported by different browsers.\" href=\"/en-US/docs/Web/HTML/Element/source\"><code>&lt;source&gt;</code></a> elements for a specific <a title=\"The HTML <img> element represents an image in the document.\" href=\"/en-US/docs/Web/HTML/Element/img\"><code>&lt;img&gt;</code></a> contained in it. The browser will choose the most suitable source according to the current layout of the page (the constraints of the box the image will appear in) and the device it will be displayed on (e.g. a normal or hiDPI device.)"
       ]
     },
     {
       "tagName" : "pre",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;pre&gt;</code> element</strong> represents preformatted text. Text within this element is typically displayed in a non-proportional (\"<a href=\"/en-US/docs/XUL/Style/monospace\">monospace</a>\") font exactly as it is laid out in the file. Whitespace inside this element is displayed as typed."
       ]
     },
     {
       "tagName" : "progress",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;progress&gt;</code> element</strong> represents the completion progress of a task, typically displayed as a progress bar."
       ]
     },
     {
       "tagName" : "q",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;q&gt;</code> element </strong> indicates that the enclosed text is a short inline quotation. This element is intended for short quotations that don't require paragraph breaks; for long quotations use the <a title=\"The HTML <blockquote> Element (or HTML Block Quotation Element) indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the <cite> element.\" href=\"/en-US/docs/Web/HTML/Element/blockquote\"><code>&lt;blockquote&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "rp",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;rp&gt;</code> element</strong> is used to provide fall-back parentheses for browsers that do not support display of ruby annotations using the <a title=\"The HTML <ruby> element represents a ruby annotation. Ruby annotations are for showing pronunciation of East Asian characters.\" href=\"/en-US/docs/Web/HTML/Element/ruby\"><code>&lt;ruby&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "rt",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;rt&gt;</code> element</strong> embraces pronunciation of characters presented in a ruby annotations, which are used to describe the pronunciation of East Asian characters. This element is always used inside a <a title=\"The HTML <ruby> element represents a ruby annotation. Ruby annotations are for showing pronunciation of East Asian characters.\" href=\"/en-US/docs/Web/HTML/Element/ruby\"><code>&lt;ruby&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "ruby",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;ruby&gt;</code> element</strong> represents a ruby annotation. Ruby annotations are for showing pronunciation of East Asian characters."
       ]
     },
     {
       "tagName" : "s",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;s&gt;</code> element</strong> renders text with a strikethrough, or a line through it. Use the <code>&lt;s&gt;</code> element to represent things that are no longer relevant or no longer accurate. However, <code>&lt;s&gt;</code> is not appropriate when indicating document edits; for that, use the <a title=\"The HTML <del> element represents a range of text that has been deleted from a document. This element is often (but need not be) rendered with strike-through text.\" href=\"/en-US/docs/Web/HTML/Element/del\"><code>&lt;del&gt;</code></a> and <a title=\"The HTML <ins> element represents a range of text that has been added to a document.\" href=\"/en-US/docs/Web/HTML/Element/ins\"><code>&lt;ins&gt;</code></a> elements, as appropriate."
       ]
     },
     {
       "tagName" : "samp",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;samp&gt;</code> element</strong> is an element intended to identify sample output from a computer program. It is usually displayed in the browser's default monotype font (such as Lucida Console)."
       ]
     },
     {
       "tagName" : "script",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;script&gt;</code> element</strong> is used to embed or reference an executable script."
       ]
     },
     {
       "tagName" : "section",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;section&gt;</code> element</strong> represents a standalone section of functionality contained within an HTML document, typically with a heading, which doesn't have a more specific semantic element to represent it."
       ]
     },
     {
       "tagName" : "select",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "<span class=\"seoSummary\">The <strong>HTML <code>&lt;select&gt;</code> element</strong> represents a control that provides a menu of options:</span>"
       ]
     },
     {
       "tagName" : "small",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;small&gt;</code></strong> <strong>element </strong>makes the text <em>font size</em> one size smaller (for example, from large to medium, or from small to x-small) down to the browser's minimum font size.&nbsp; In HTML5, this element is repurposed to represent side-comments and small print, including copyright and legal text, independent of its styled presentation."
       ]
     },
     {
       "tagName" : "source",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;source&gt;</code> element</strong> specifies multiple media resources for either the <a title=\"The HTML <picture> element is a container used to specify multiple <source> elements for a specific <img> contained in it. The browser will choose the most suitable source according to the current layout of the page (the constraints of the box the image will appear in) and the device it will be displayed on (e.g. a normal or hiDPI device.)\" href=\"/en-US/docs/Web/HTML/Element/picture\"><code>&lt;picture&gt;</code></a>, the <a title=\"The HTML <audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the <source> element:&nbsp;the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.\" href=\"/en-US/docs/Web/HTML/Element/audio\"><code>&lt;audio&gt;</code></a> or the <a title=\"Use the HTML <video> element to embed video content in a document.\" href=\"/en-US/docs/Web/HTML/Element/video\"><code>&lt;video&gt;</code></a> element. It is an empty element. It is commonly used to serve the same media content in <a href=\"/en-US/docs/Media_formats_supported_by_the_audio_and_video_elements\">multiple formats supported by different browsers</a>."
       ]
     },
     {
       "tagName" : "span",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "<span class=\"seoSummary\">The <strong>HTML <code>&lt;span&gt;</code> element</strong> is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the <code>class</code> or <code>id</code> attributes), or because they share attribute values, such as <code>lang</code>.</span> It should be used only when no other semantic element is appropriate. <code>&lt;span&gt;</code> is very much like a <a title=\"The HTML <div> element is the generic container for flow content and does not inherently represent anything. Use it to group elements for purposes such as styling (using the class or id attributes), marking a section of a document in a different language (using the lang attribute), and so on.\" href=\"/en-US/docs/Web/HTML/Element/div\"><code>&lt;div&gt;</code></a> element, but <a title=\"The HTML <div> element is the generic container for flow content and does not inherently represent anything. Use it to group elements for purposes such as styling (using the class or id attributes), marking a section of a document in a different language (using the lang attribute), and so on.\" href=\"/en-US/docs/Web/HTML/Element/div\"><code>&lt;div&gt;</code></a> is a <a href=\"/en-US/docs/HTML/Block-level_elements\">block-level element</a> whereas a <code>&lt;span&gt;</code> is an<a href=\"/en-US/docs/HTML/Inline_elements\"> inline element</a>."
       ]
     },
     {
       "tagName" : "strong",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML </strong><code><strong>&lt;strong&gt;</strong></code><strong> element</strong> gives text strong importance, and is typically displayed in bold."
       ]
     },
     {
       "tagName" : "style",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;style&gt;</code> element</strong> contains style information for a document, or part of a document. By default, the style instructions written inside that element are expected to be <a href=\"/en-US/docs/Web/CSS\">CSS</a>."
       ]
     },
     {
       "tagName" : "sub",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;sub&gt;</code> element</strong> defines a span of text that should be displayed, for typographic reasons, lower, and often smaller, than the main span of text."
       ]
     },
     {
       "tagName" : "summary",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;summary&gt;</code> element</strong> is used as a summary, caption, or legend for the content of a <a title=\"The HTML <details> element is used as a disclosure widget from which the user can retrieve additional information.\" href=\"/en-US/docs/Web/HTML/Element/details\"><code>&lt;details&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "sup",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;sup&gt;</code> element</strong> defines a span of text that should be displayed, for typographic reasons, higher, and often smaller, than the main span of text."
       ]
     },
     {
       "tagName" : "table",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;table&gt;</code> element</strong> represents tabular data — that is, information expressed via a two-dimensional data table."
       ]
     },
     {
       "tagName" : "tbody",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;tbody&gt;</code> element</strong> groups one or more <a title=\"The HTML <tr> element specifies that the markup contained inside the <tr> block comprises one row of a table, inside which the <th> and <td> elements create header and data cells, respectively, within the row.\" href=\"/en-US/docs/Web/HTML/Element/tr\"><code>&lt;tr&gt;</code></a> elements as the body of a <a title=\"The HTML <table> element represents tabular data — that is, information expressed via a two-dimensional data table.\" href=\"/en-US/docs/Web/HTML/Element/table\"><code>&lt;table&gt;</code></a> element."
       ]
     },
     {
       "tagName" : "td",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;td&gt;</code> element</strong> defines a cell of a table that contains data. It participates in the <em>table model</em>."
       ]
     },
     {
       "tagName" : "textarea",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;textarea&gt;</code> element</strong> represents a multi-line plain-text editing control."
       ]
     },
     {
       "tagName" : "tfoot",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;tfoot&gt;</code> element</strong> defines a set of rows summarizing the columns of the table."
       ]
     },
     {
       "tagName" : "th",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "<span class=\"seoSummary\">The <strong>HTML <code>&lt;th&gt;</code> element</strong> defines a cell as header of a group of table cells. The exact nature of this group is defined by the <code><a href=\"/en-US/docs/Web/HTML/Element/th#attr-scope\">scope</a></code> and <code><a href=\"/en-US/docs/Web/HTML/Element/th#attr-headers\">headers</a></code> attributes.</span>"
       ]
     },
     {
       "tagName" : "thead",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;thead&gt;</code> element</strong> defines a set of rows defining the head of the columns of the table."
       ]
     },
     {
       "tagName" : "time",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;time&gt;</code> element</strong> represents either a time on a 24-hour clock or a precise date in the <a class=\"external\" href=\"https://en.wikipedia.org/wiki/Gregorian_calendar\">Gregorian calendar</a> (with optional time and timezone information)."
       ]
     },
     {
       "tagName" : "title",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;title&gt;</code> element</strong> defines the title of the document, shown in a browser's title bar or on the page's tab. It can only contain text, and any contained tags are ignored."
       ]
     },
     {
       "tagName" : "tr",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;tr&gt;</code> element</strong> defines a row of cells in a table. Those can be a mix of <a title=\"The HTML <td> element defines a cell of a table that contains data. It participates in the table model.\" href=\"/en-US/docs/Web/HTML/Element/td\"><code>&lt;td&gt;</code></a> and <a title=\"The HTML <th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes.\" href=\"/en-US/docs/Web/HTML/Element/th\"><code>&lt;th&gt;</code></a> elements."
       ]
     },
     {
       "tagName" : "track",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;track&gt;</code> element</strong> is used as a child of the media elements <a title=\"The HTML <audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the <source> element:&nbsp;the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.\" href=\"/en-US/docs/Web/HTML/Element/audio\"><code>&lt;audio&gt;</code></a> and <a title=\"Use the HTML <video> element to embed video content in a document.\" href=\"/en-US/docs/Web/HTML/Element/video\"><code>&lt;video&gt;</code></a>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in <a href=\"/en-US/docs/Web/API/Web_Video_Text_Tracks_Format\">WebVTT format</a> (<code>.vtt</code> files) — Web Video Text Tracks."
       ]
     },
     {
       "tagName" : "u",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;u&gt;</code> element</strong> renders text with an underline, a line under the baseline of its content. In HTML5, this element represents a span of text with an unarticulated, though explicitly rendered, non-textual annotation, such as labeling the text as being a proper name in Chinese text (a Chinese proper name mark), or labeling the text as being misspelled."
       ]
     },
     {
       "tagName" : "ul",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The<strong> HTML <code>&lt;ul&gt;</code> element</strong> represents an unordered list of items, typically rendered as a bulleted list."
       ]
     },
     {
       "tagName" : "var",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;var&gt;</code> element</strong> represents a variable in a mathematical expression or a programming context."
       ]
     },
     {
       "tagName" : "video",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "Use the <strong>HTML <code>&lt;video&gt;</code> element</strong> to embed video content in a document."
       ]
     },
     {
       "tagName" : "wbr",
+      "scalajsDomType": "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
         "The <strong>HTML <code>&lt;wbr&gt;</code> element</strong> represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location."
       ]

--- a/web/html.json
+++ b/web/html.json
@@ -801,7 +801,7 @@
     },
     {
       "attributeName" : "onToggle",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -823,7 +823,7 @@
     },
     {
       "attributeName" : "onClose",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -870,7 +870,7 @@
     },
     {
       "attributeName" : "onPlaying",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -890,7 +890,7 @@
     },
     {
       "attributeName" : "onTimeUpdate",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -899,7 +899,7 @@
     },
     {
       "attributeName" : "onSubmit",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -919,7 +919,7 @@
     },
     {
       "attributeName" : "onLoad",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -982,7 +982,7 @@
     },
     {
       "attributeName" : "onDragEnd",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -991,7 +991,7 @@
     },
     {
       "attributeName" : "onFocus",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1009,7 +1009,7 @@
     },
     {
       "attributeName" : "onWaiting",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1033,7 +1033,7 @@
     },
     {
       "attributeName" : "onError",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1042,7 +1042,7 @@
     },
     {
       "attributeName" : "onDragExit",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1051,7 +1051,7 @@
     },
     {
       "attributeName" : "onLoadStart",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1060,7 +1060,7 @@
     },
     {
       "attributeName" : "onAutoComplete",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1094,7 +1094,7 @@
     },
     {
       "attributeName" : "onContextMenu",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1129,7 +1129,7 @@
     },
     {
       "attributeName" : "onScroll",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1169,7 +1169,7 @@
     },
     {
       "attributeName" : "onInput",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1215,7 +1215,7 @@
     },
     {
       "attributeName" : "onCanPlay",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1233,7 +1233,7 @@
     },
     {
       "attributeName" : "onClick",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1242,7 +1242,7 @@
     },
     {
       "attributeName" : "onLoadedData",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1284,7 +1284,7 @@
     },
     {
       "attributeName" : "onShow",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1293,7 +1293,7 @@
     },
     {
       "attributeName" : "onSort",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1313,7 +1313,7 @@
     },
     {
       "attributeName" : "onMouseUp",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
         ""
       ],
@@ -1322,7 +1322,7 @@
     },
     {
       "attributeName" : "onCueChange",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1331,7 +1331,7 @@
     },
     {
       "attributeName" : "onInvalid",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1397,7 +1397,7 @@
     },
     {
       "attributeName" : "onKeyUp",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1465,7 +1465,7 @@
     },
     {
       "attributeName" : "onSelect",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1474,7 +1474,7 @@
     },
     {
       "attributeName" : "onResize",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1492,7 +1492,7 @@
     },
     {
       "attributeName" : "onDrag",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1547,7 +1547,7 @@
     },
     {
       "attributeName" : "onMouseMove",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
         ""
       ],
@@ -1556,7 +1556,7 @@
     },
     {
       "attributeName" : "onMouseDown",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
         ""
       ],
@@ -1565,7 +1565,7 @@
     },
     {
       "attributeName" : "onPause",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1600,7 +1600,7 @@
     },
     {
       "attributeName" : "onMouseEnter",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
         ""
       ],
@@ -1609,7 +1609,7 @@
     },
     {
       "attributeName" : "onDrop",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1618,7 +1618,7 @@
     },
     {
       "attributeName" : "onEnded",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1715,7 +1715,7 @@
     },
     {
       "attributeName" : "onEmptied",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1744,7 +1744,7 @@
     },
     {
       "attributeName" : "onMouseOver",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
         ""
       ],
@@ -1753,7 +1753,7 @@
     },
     {
       "attributeName" : "onCanPlayThrough",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1773,7 +1773,7 @@
     },
     {
       "attributeName" : "onAbort",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1821,7 +1821,7 @@
     },
     {
       "attributeName" : "onLoadedMetadata",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1856,7 +1856,7 @@
     },
     {
       "attributeName" : "onPlay",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1910,7 +1910,7 @@
     },
     {
       "attributeName" : "onProgress",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1919,7 +1919,7 @@
     },
     {
       "attributeName" : "onCancel",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1928,7 +1928,7 @@
     },
     {
       "attributeName" : "onReset",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1965,7 +1965,7 @@
     },
     {
       "attributeName" : "onKeyDown",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -1985,7 +1985,7 @@
     },
     {
       "attributeName" : "onStalled",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2060,7 +2060,7 @@
     },
     {
       "attributeName" : "onMouseLeave",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
         ""
       ],
@@ -2104,7 +2104,7 @@
     },
     {
       "attributeName" : "onDragOver",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2113,7 +2113,7 @@
     },
     {
       "attributeName" : "onDoubleClick",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2144,7 +2144,7 @@
     },
     {
       "attributeName" : "onAutoCompleteError",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2212,7 +2212,7 @@
     },
     {
       "attributeName" : "onDragStart",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2234,7 +2234,7 @@
     },
     {
       "attributeName" : "onSuspend",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2254,7 +2254,7 @@
     },
     {
       "attributeName" : "onSeeked",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2263,7 +2263,7 @@
     },
     {
       "attributeName" : "onMouseOut",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
         ""
       ],
@@ -2272,7 +2272,7 @@
     },
     {
       "attributeName" : "onMouseWheel",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
         ""
       ],
@@ -2290,7 +2290,7 @@
     },
     {
       "attributeName" : "onSeeking",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2299,7 +2299,7 @@
     },
     {
       "attributeName" : "onChange",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2308,7 +2308,7 @@
     },
     {
       "attributeName" : "onBlur",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2317,7 +2317,7 @@
     },
     {
       "attributeName" : "onKeyPress",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2339,7 +2339,7 @@
     },
     {
       "attributeName" : "onDragLeave",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2348,7 +2348,7 @@
     },
     {
       "attributeName" : "onDragEnter",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2378,7 +2378,7 @@
     },
     {
       "attributeName" : "onVolumeChange",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2402,7 +2402,7 @@
     },
     {
       "attributeName" : "onDurationChange",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],
@@ -2484,7 +2484,7 @@
     },
     {
       "attributeName" : "onRateChange",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
         ""
       ],

--- a/web/src/main/scala/me/shadaj/slinky/web/SyntheticMouseEvent.scala
+++ b/web/src/main/scala/me/shadaj/slinky/web/SyntheticMouseEvent.scala
@@ -1,0 +1,23 @@
+package me.shadaj.slinky.web
+
+import me.shadaj.slinky.core.facade.SyntheticEvent
+
+import scala.scalajs.js
+
+@js.native
+trait SyntheticMouseEvent[T] extends SyntheticEvent[T] {
+  val altKey: Boolean = js.native
+  val button: Int = js.native
+  val buttons: Int = js.native
+  val clientX: Int = js.native
+  val clientY: Int = js.native
+  val ctrlKey: Boolean = js.native
+  def getModifierState(key: Int): Boolean = js.native
+  val metaKey: Boolean = js.native
+  val pageX: Int = js.native
+  val pageY: Int = js.native
+  val relatedTarget: T = js.native
+  val screenX: Int = js.native
+  val screenY: Int = js.native
+  val shiftKey: Boolean = js.native
+}

--- a/web/svg.json
+++ b/web/svg.json
@@ -2,366 +2,439 @@
   "tags" : [
     {
       "tagName" : "a",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "altGlyph",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "altGlyphDef",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "altGlyphItem",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "animate",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "animateColor",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "animateMotion",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "animateTransform",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "circle",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "clipPath",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "cursor",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "defs",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "desc",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "ellipse",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feBlend",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feColorMatrix",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feComponentTransfer",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feComposite",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feConvolveMatrix",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feDiffuseLighting",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feDisplacementMap",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feDistantLight",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feFlood",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feFuncA",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feFuncB",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feFuncG",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feFuncR",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feGaussianBlur",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feImage",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feMerge",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feMergeNode",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feMorphology",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feOffset",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "fePointLight",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feSpecularLighting",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feSpotLight",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feTile",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "feTurbulence",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "filter",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "font",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "foreignObject",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "g",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "glyph",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "glyphRef",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "hkern",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "image",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "line",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "linearGradient",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "marker",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "mask",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "metadata",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "mpath",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "path",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "pattern",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "polygon",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "polyline",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "radialGradient",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "rect",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "script",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "set",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "stop",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "style",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "svg",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "switch",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "symbol",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "text",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "textPath",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "title",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "tref",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "tspan",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "use",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "view",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     },
     {
       "tagName" : "vkern",
+      "scalajsDomType" : "org.scalajs.dom.raw.HTMLElement",
       "docLines" : [
       ]
     }

--- a/web/svg.json
+++ b/web/svg.json
@@ -2354,7 +2354,7 @@
     },
     {
       "attributeName" : "onAbort",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2362,7 +2362,7 @@
     },
     {
       "attributeName" : "onAutoComplete",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2370,7 +2370,7 @@
     },
     {
       "attributeName" : "onAutoCompleteError",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2378,7 +2378,7 @@
     },
     {
       "attributeName" : "onBlur",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2386,7 +2386,7 @@
     },
     {
       "attributeName" : "onCancel",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2394,7 +2394,7 @@
     },
     {
       "attributeName" : "onCanPlay",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2402,7 +2402,7 @@
     },
     {
       "attributeName" : "onCanPlayThrough",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2410,7 +2410,7 @@
     },
     {
       "attributeName" : "onChange",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2418,7 +2418,7 @@
     },
     {
       "attributeName" : "onClick",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2426,7 +2426,7 @@
     },
     {
       "attributeName" : "onClose",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2434,7 +2434,7 @@
     },
     {
       "attributeName" : "onContextMenu",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2442,7 +2442,7 @@
     },
     {
       "attributeName" : "onCueChange",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2450,7 +2450,7 @@
     },
     {
       "attributeName" : "onDoubleClick",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2458,7 +2458,7 @@
     },
     {
       "attributeName" : "onDrag",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2466,7 +2466,7 @@
     },
     {
       "attributeName" : "onDragEnd",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2474,7 +2474,7 @@
     },
     {
       "attributeName" : "onDragEnter",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2482,7 +2482,7 @@
     },
     {
       "attributeName" : "onDragExit",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2490,7 +2490,7 @@
     },
     {
       "attributeName" : "onDragLeave",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2498,7 +2498,7 @@
     },
     {
       "attributeName" : "onDragOver",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2506,7 +2506,7 @@
     },
     {
       "attributeName" : "onDragStart",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2514,7 +2514,7 @@
     },
     {
       "attributeName" : "onDrop",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2522,7 +2522,7 @@
     },
     {
       "attributeName" : "onDurationChange",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2530,7 +2530,7 @@
     },
     {
       "attributeName" : "onEmptied",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2538,7 +2538,7 @@
     },
     {
       "attributeName" : "onEnded",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2546,7 +2546,7 @@
     },
     {
       "attributeName" : "onError",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2554,7 +2554,7 @@
     },
     {
       "attributeName" : "onFocus",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2562,7 +2562,7 @@
     },
     {
       "attributeName" : "onInput",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2570,7 +2570,7 @@
     },
     {
       "attributeName" : "onInvalid",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2578,7 +2578,7 @@
     },
     {
       "attributeName" : "onKeyDown",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2586,7 +2586,7 @@
     },
     {
       "attributeName" : "onKeyPress",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2594,7 +2594,7 @@
     },
     {
       "attributeName" : "onKeyUp",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2602,7 +2602,7 @@
     },
     {
       "attributeName" : "onLoad",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2610,7 +2610,7 @@
     },
     {
       "attributeName" : "onLoadedData",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2618,7 +2618,7 @@
     },
     {
       "attributeName" : "onLoadedMetadata",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2626,7 +2626,7 @@
     },
     {
       "attributeName" : "onLoadStart",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2634,7 +2634,7 @@
     },
     {
       "attributeName" : "onMouseDown",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2642,7 +2642,7 @@
     },
     {
       "attributeName" : "onMouseEnter",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2650,7 +2650,7 @@
     },
     {
       "attributeName" : "onMouseLeave",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2658,7 +2658,7 @@
     },
     {
       "attributeName" : "onMouseMove",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2666,7 +2666,7 @@
     },
     {
       "attributeName" : "onMouseOut",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2674,7 +2674,7 @@
     },
     {
       "attributeName" : "onMouseOver",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2682,7 +2682,7 @@
     },
     {
       "attributeName" : "onMouseUp",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2690,7 +2690,7 @@
     },
     {
       "attributeName" : "onMouseWheel",
-      "attributeType" : "MouseEventHandler",
+      "attributeType" : "me.shadaj.slinky.web.SyntheticMouseEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2698,7 +2698,7 @@
     },
     {
       "attributeName" : "onPause",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2706,7 +2706,7 @@
     },
     {
       "attributeName" : "onPlay",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2714,7 +2714,7 @@
     },
     {
       "attributeName" : "onPlaying",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2722,7 +2722,7 @@
     },
     {
       "attributeName" : "onProgress",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2730,7 +2730,7 @@
     },
     {
       "attributeName" : "onRateChange",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2738,7 +2738,7 @@
     },
     {
       "attributeName" : "onReset",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2746,7 +2746,7 @@
     },
     {
       "attributeName" : "onResize",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2754,7 +2754,7 @@
     },
     {
       "attributeName" : "onScroll",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2762,7 +2762,7 @@
     },
     {
       "attributeName" : "onSeeked",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2770,7 +2770,7 @@
     },
     {
       "attributeName" : "onSeeking",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2778,7 +2778,7 @@
     },
     {
       "attributeName" : "onSelect",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2786,7 +2786,7 @@
     },
     {
       "attributeName" : "onShow",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2794,7 +2794,7 @@
     },
     {
       "attributeName" : "onSort",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2802,7 +2802,7 @@
     },
     {
       "attributeName" : "onStalled",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2810,7 +2810,7 @@
     },
     {
       "attributeName" : "onSubmit",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2818,7 +2818,7 @@
     },
     {
       "attributeName" : "onSuspend",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2826,7 +2826,7 @@
     },
     {
       "attributeName" : "onTimeUpdate",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2834,7 +2834,7 @@
     },
     {
       "attributeName" : "onToggle",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2842,7 +2842,7 @@
     },
     {
       "attributeName" : "onVolumeChange",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -2850,7 +2850,7 @@
     },
     {
       "attributeName" : "onWaiting",
-      "attributeType" : "EventHandler",
+      "attributeType" : "me.shadaj.slinky.core.facade.SyntheticEvent",
       "docLines" : [
       ],
       "compatibleTags" : null,


### PR DESCRIPTION
Before, events and attributes like `ref` would always receive an `HTMLElement` reference to DOM nodes. Now, with some method overloading magic, those same attributes and events automatically receive DOM nodes typed specifically for the tag they are being applied to.

IDE support in IntelliJ depends on https://youtrack.jetbrains.com/issue/SCL-13027

This fixes #24 