### PR TITLE
Bump Scala version to 2.12.6 and fix provider macros

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization in ThisBuild := "me.shadaj"
 
-scalaVersion in ThisBuild := "2.12.4"
+scalaVersion in ThisBuild := "2.12.6"
 
 scalacOptions in ThisBuild ++= Seq("-feature", "-deprecation")
 

--- a/core/src/main/scala/slinky/core/BaseComponentWrapper.scala
+++ b/core/src/main/scala/slinky/core/BaseComponentWrapper.scala
@@ -174,8 +174,7 @@ object PropsReaderProvider {
   def impl(c: blackbox.Context): c.Expr[PropsReaderProvider] = {
     import c.universe._
     val compName = c.internal.enclosingOwner.owner.asClass
-    val readerType = tq"_root_.slinky.readwrite.Reader[$compName.Props]"
-    val q"val x: $typedReaderType = null" = c.typecheck(q"val x: $readerType = null")
+    val q"$_; val x: $typedReaderType = null" = c.typecheck(q"@_root_.scala.annotation.unchecked.uncheckedStable val comp: $compName = null; val x: _root_.slinky.readwrite.Reader[comp.Props] = null")
     val tpcls = c.inferImplicitValue(typedReaderType.tpe.asInstanceOf[c.Type])
     c.Expr(q"if (_root_.scala.scalajs.LinkingInfo.productionMode) null else $tpcls.asInstanceOf[_root_.slinky.core.PropsReaderProvider]")
   }
@@ -188,8 +187,7 @@ object PropsWriterProvider {
   def impl(c: blackbox.Context): c.Expr[PropsWriterProvider] = {
     import c.universe._
     val compName = c.internal.enclosingOwner.owner.asClass
-    val readerType = tq"_root_.slinky.readwrite.Writer[$compName.Props]"
-    val q"val x: $typedReaderType = null" = c.typecheck(q"val x: $readerType = null")
+    val q"$_; val x: $typedReaderType = null" = c.typecheck(q"@_root_.scala.annotation.unchecked.uncheckedStable val comp: $compName = null; val x: _root_.slinky.readwrite.Writer[comp.Props] = null")
     val tpcls = c.inferImplicitValue(typedReaderType.tpe.asInstanceOf[c.Type])
     c.Expr(q"if (_root_.scala.scalajs.LinkingInfo.productionMode) null else $tpcls.asInstanceOf[_root_.slinky.core.PropsWriterProvider]")
   }
@@ -202,8 +200,7 @@ object StateReaderProvider {
   def impl(c: blackbox.Context): c.Expr[StateReaderProvider] = {
     import c.universe._
     val compName = c.internal.enclosingOwner.owner.asClass
-    val readerType = tq"_root_.slinky.readwrite.Reader[$compName.State]"
-    val q"val x: $typedReaderType = null" = c.typecheck(q"val x: $readerType = null")
+    val q"$_; val x: $typedReaderType = null" = c.typecheck(q"@_root_.scala.annotation.unchecked.uncheckedStable val comp: $compName = null; val x: _root_.slinky.readwrite.Reader[comp.State] = null")
     val tpcls = c.inferImplicitValue(typedReaderType.tpe.asInstanceOf[c.Type])
     c.Expr(q"if (_root_.scala.scalajs.LinkingInfo.productionMode) null else $tpcls.asInstanceOf[_root_.slinky.core.StateReaderProvider]")
   }
@@ -216,8 +213,7 @@ object StateWriterProvider {
   def impl(c: blackbox.Context): c.Expr[StateWriterProvider] = {
     import c.universe._
     val compName = c.internal.enclosingOwner.owner.asClass
-    val readerType = tq"_root_.slinky.readwrite.Writer[$compName.State]"
-    val q"val x: $typedReaderType = null" = c.typecheck(q"val x: $readerType = null")
+    val q"$_; val x: $typedReaderType = null" = c.typecheck(q"@_root_.scala.annotation.unchecked.uncheckedStable val comp: $compName = null; val x: _root_.slinky.readwrite.Writer[comp.State] = null")
     val tpcls = c.inferImplicitValue(typedReaderType.tpe.asInstanceOf[c.Type])
     c.Expr(q"if (_root_.scala.scalajs.LinkingInfo.productionMode) null else $tpcls.asInstanceOf[_root_.slinky.core.StateWriterProvider]")
   }

--- a/core/src/main/scala/slinky/core/ExternalComponent.scala
+++ b/core/src/main/scala/slinky/core/ExternalComponent.scala
@@ -94,13 +94,13 @@ abstract class ExternalComponentNoPropsWithRefType[R <: js.Object]
 
 abstract class ExternalComponentNoProps extends ExternalComponentNoPropsWithAttributes[Nothing]
 
+// same as PropsWriterProvider except it always returns the typeclass instead of nulling it out in fullOpt mode
 trait ExternalPropsWriterProvider extends js.Object
 object ExternalPropsWriterProvider {
   def impl(c: blackbox.Context): c.Expr[ExternalPropsWriterProvider] = {
     import c.universe._
     val compName = c.internal.enclosingOwner.owner.asClass
-    val readerType = tq"_root_.slinky.readwrite.Writer[$compName.Props]"
-    val q"val x: $typedReaderType = null" = c.typecheck(q"val x: $readerType = null")
+    val q"$_; val x: $typedReaderType = null" = c.typecheck(q"@_root_.scala.annotation.unchecked.uncheckedStable val comp: $compName = null; val x: _root_.slinky.readwrite.Writer[comp.Props] = null")
     val tpcls = c.inferImplicitValue(typedReaderType.tpe.asInstanceOf[c.Type])
     c.Expr(q"$tpcls.asInstanceOf[_root_.slinky.core.ExternalPropsWriterProvider]")
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.6

--- a/tests/src/test/scala/slinky/core/TagTest.scala
+++ b/tests/src/test/scala/slinky/core/TagTest.scala
@@ -9,8 +9,6 @@ import scala.scalajs.js
 import org.scalajs.dom
 import org.scalajs.dom.MouseEvent
 
-import scala.scalajs.js.annotation.ScalaJSDefined
-
 class InnerClassCustom extends js.Object {
   val customTag = new CustomTag("custom-element")
   val customClass = new CustomAttribute[String]("class")


### PR DESCRIPTION
The previous provider macros, which grab the typeclass for the Props/State members of component objects at the wrapper constructor level. In Scala 2.12.4, there was a bug that allowed illegal qualifiers (https://github.com/scala/scala/pull/6359), which allowed the macro implmementations to run without failures. But in 2.12.5, this was fixed and so all the provider macros began to fail with errors for not having a stable identifier. This PR fixes the macros by creating an intermediate variable annotated with `@uncheckedStable`, which lets us access the Props/State types even though we use an unstable path.

Fixes #142