### PR TITLE
Various reader/writer improvements

### DIFF
--- a/readWrite/src/main/scala/slinky/readwrite/CoreWriters.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreWriters.scala
@@ -157,6 +157,17 @@ trait CoreWriters extends MacroWriters with FallbackWriters {
     js.Array(s.toSeq.map(v => writer.write(v)): _*).asInstanceOf[js.Object]
   }
 
+  implicit def mapWriter[A, B](implicit abWriter: Writer[(A, B)]): Writer[Map[A, B]] = s => {
+    collectionWriter[(A, B), Iterable].write(s)
+  }
+
+  implicit val rangeWriter: Writer[Range] = r => {
+    js.Dynamic.literal(start = r.start, end = r.end, step = r.step, inclusive = r.isInclusive)
+  }
+
+  implicit val inclusiveRangeWriter: Writer[Range.Inclusive] =
+    rangeWriter.asInstanceOf[Writer[Range.Inclusive]]
+
   implicit def futureWriter[O](implicit oWriter: Writer[O]): Writer[Future[O]] = s => {
     import scala.scalajs.js.JSConverters._
     s.map(v => oWriter.write(v)).toJSPromise.asInstanceOf[js.Object]

--- a/tests/src/test/scala/slinky/core/ReaderWriterTest.scala
+++ b/tests/src/test/scala/slinky/core/ReaderWriterTest.scala
@@ -14,6 +14,8 @@ case class SubTypeA(int: Int) extends MySealedTrait
 case class SubTypeB(boolean: Boolean) extends MySealedTrait
 case object SubTypeC extends MySealedTrait
 
+case class ClassWithVararg(a: Int, bs: String*)
+
 class ReaderWriterTest extends FunSuite {
   private def readWrittenSame[T](v: T, isOpaque: Boolean = false, beSame: Boolean = true)(implicit reader: Reader[T], writer: Writer[T]) = {
     val written = writer.write(v)
@@ -134,6 +136,10 @@ class ReaderWriterTest extends FunSuite {
     readWrittenSame(ComplexClass(TypeA(), _ => 1), beSame = false)
   }
 
+  test("Read/write - case class with varargs") {
+    readWrittenSame(ClassWithVararg(1, "hi", "hi", "bye"))
+  }
+
   test("Read/write - value class") {
     readWrittenSame(new ValueClass(1))
 
@@ -145,8 +151,31 @@ class ReaderWriterTest extends FunSuite {
     readWrittenSame(List(1, 2))
   }
 
+  test("Read/write - maps") {
+    readWrittenSame(Map(1 -> 2, 3 -> 4))
+  }
+
+  test("Read/write - ranges (inclusive)") {
+    readWrittenSame(1 to 10)
+  }
+
+  test("Read/write - ranges (exclusive)") {
+    readWrittenSame(1 until 10)
+  }
+
   test("Read/write - opaque class") {
     class OpaqueClass(int: Int)
     readWrittenSame(new OpaqueClass(1), true)
+  }
+
+  // compilation test: can use derivation macro with type parameter when typeclass is available
+  {
+    def deriveReaderTypeclass[T: Reader]: Reader[T] = {
+      Reader.deriveReader[T]
+    }
+
+    def deriveWriterTypeclass[T: Writer]: Writer[T] = {
+      Writer.deriveWriter[T]
+    }
   }
 }


### PR DESCRIPTION
1. Fix derivation when there are vararg parameters
2. Implement reader/writer for Map[A, B]
3. Fix derivation not working with type parameters even when the needed typeclass is available
4. Impelement reader/writer for Range(.Inclusive), fix #164