### PR TITLE
Use the exact wording in enabling extensions

### DIFF
--- a/docs/public/docs/installation.md
+++ b/docs/public/docs/installation.md
@@ -36,7 +36,7 @@ as `window.React` and React DOM as `window.ReactDOM`.
 While Slinky can be in a simple Scala.js app with no bundler, we highly recommend that you use [webpack](https://webpack.js.org/) for bundling your application with its dependencies. The SBT plugin [scalajs-bundler](https://scalacenter.github.io/scalajs-bundler/) automates much of the process around configuring webpack, and is very useful for adding webpack to an SBT build setup.
 
 ## IntelliJ Support
-Starting with Slinky 0.5.0, the `@react` macro annotation is implemented with Macro Paradise to ensure compatibility with future versions of Scala, so a small extra step is required to enable IDE support in IntelliJ. After loading, your project, enable library extensions in `Settings > Languages & Frameworks > Scala > Extensions`. After applying these settings and refreshing your SBT project again, IntelliJ will pop up with a request to enable Slinky support.
+Starting with Slinky 0.5.0, the `@react` macro annotation is implemented with Macro Paradise to ensure compatibility with future versions of Scala, so a small extra step is required to enable IDE support in IntelliJ. After loading, your project, check `Enable loading external extensions` in `Settings > Languages & Frameworks > Scala > Extensions`. After applying these settings and refreshing your SBT project again, IntelliJ will pop up with a request to enable Slinky support.
 
 ## Credits
 Much credit goes to existing Scala.js libraries for React, such as [scalajs-react](https://github.com/japgolly/scalajs-react), which provided a lot of inspiration for Slinky's design. Credit also goes to [scala-js-preact](https://github.com/LMnet/scala-js-preact), which provided the inspiration for the `@react` macro annotation. 


### PR DESCRIPTION
The label for enabling library extensions is Enable loading external extensions, so use that in docs to avoid any confusion.