### PR TITLE
Fix read of Option[T] when T has a fallback writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
 ## vNEXT
-## Details
+## Features
++ Support reading and writing `scala.Array` [PR #187](https://github.com/shadaj/slinky/pull/187)
++ Support the `defaultValue` attribute for specifying a default form value without overriding user inputs [PR #186](https://github.com/shadaj/slinky/pull/186)
+
+## Bug Fixes
++ Prevent crashes with components that store an `Option` of an opaque type in their `State` [PR #198](https://github.com/shadaj/slinky/pull/198)
 + Fix `ComponentWrapper`s not picking up manually defined Reader/Writers for the `State` type [PR #190](https://github.com/shadaj/slinky/pull/190)
 + Fix how the IntelliJ extensions handles components that have a `children` prop but no other props [PR #189](https://github.com/shadaj/slinky/pull/189)
 + Fix errors when using the `@react` macro annotation with `Component`/`StatelessComponent` imported locally [PR #188](https://github.com/shadaj/slinky/pull/188)
-+ Support reading and writing `scala.Array` [PR #187](https://github.com/shadaj/slinky/pull/187)
-+ Support the `defaultValue` attribute for specifying a default form value without overriding user inputs [PR #186](https://github.com/shadaj/slinky/pull/186)
 + Fix the `value` attribute not being available on the `select` and `textarea` tags [PR #177](https://github.com/shadaj/slinky/pull/177)
 + Bump Scala version to 2.12.7 and SBT/plugin versions as well [PR #176](https://github.com/shadaj/slinky/pull/176)
 

--- a/readWrite/build.sbt
+++ b/readWrite/build.sbt
@@ -78,6 +78,11 @@ sourceGenerators in Compile += Def.task {
        |  protected def forceRead(o: js.Object): P
        |}
        |
+       |trait AlwaysReadReader[P] extends Reader[P] {
+       |  override def read(o: js.Object): P = forceRead(o)
+       |  protected def forceRead(o: js.Object): P
+       |}
+       |
        |object Reader extends CoreReaders {
        |  ${gens.mkString("\n")}
        |}""".stripMargin)

--- a/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
@@ -137,13 +137,13 @@ trait CoreReaders extends MacroReaders with FallbackReaders {
     }
   }
 
-  implicit def optionReader[T](implicit reader: Reader[T]): Reader[Option[T]] = s => {
+  implicit def optionReader[T](implicit reader: Reader[T]): Reader[Option[T]] = (s => {
     if (js.isUndefined(s) || s == null) {
       None
     } else {
       Some(reader.read(s))
     }
-  }
+  }): AlwaysReadReader[Option[T]]
 
   implicit def eitherReader[A, B](implicit aReader: Reader[A], bReader: Reader[B]): Reader[Either[A, B]] = o => {
     if (o.asInstanceOf[js.Dynamic].isLeft.asInstanceOf[Boolean]) {

--- a/tests/src/test/scala/slinky/core/ReaderWriterTest.scala
+++ b/tests/src/test/scala/slinky/core/ReaderWriterTest.scala
@@ -176,6 +176,13 @@ class ReaderWriterTest extends FunSuite {
     readWrittenSame(new OpaqueClass(1), true)
   }
 
+  test("Read/write - option of opaque class") {
+    class OpaqueClass(int: Int)
+    assert(implicitly[Reader[Option[OpaqueClass]]].read(
+      implicitly[Writer[Option[OpaqueClass]]].write(Some(new OpaqueClass(1)))
+    ).get != null)
+  }
+
   // compilation test: can use derivation macro with type parameter when typeclass is available
   {
     def deriveReaderTypeclass[T: Reader]: Reader[T] = {


### PR DESCRIPTION
Originally reported by @gavares in https://gitter.im/shadaj/slinky?at=5bd3a5dee4b1d87dc792bc60