### PR TITLE
Update documentation code examples.

### DIFF
--- a/docs/public/docs/fragments-and-portals.md
+++ b/docs/public/docs/fragments-and-portals.md
@@ -6,7 +6,7 @@ Slinky supports the special fragment and portal element types that were introduc
 
 ```scala
 @react class MyComponent extends StatelessComponent {
-  trait Props = Unit
+  case class Props()
   
   def render = {
     List(
@@ -24,7 +24,7 @@ Additionally, Slinky supports the `Fragment` component [introduced in React 16.2
 import slinky.core.facade.Fragment
 
 @react class MyComponent extends StatelessComponent {
-  trait Props = Unit
+  case class Props()
   
   def render = {
     Fragment(

--- a/docs/public/docs/writing-components.md
+++ b/docs/public/docs/writing-components.md
@@ -44,7 +44,7 @@ So a full component would look something like this:
 
 ```scala
 @react class MyComponent extends Component {
-  type Props = Unit // no props
+  case class Props() // no props
   case class State(buttonPresses: Int)
   
   def initialState = State(0)


### PR DESCRIPTION
In documentation code examples you specifying React component properties as `type Props = Unit`. I faced with issues at compilation time and I think this is too wide for scala compilator when it try to compile code with implicit types. Better specify components without props with case class like `case class Props()`.