### PR TITLE
Fix default parameters compile errors when deriving readers for component state

### DIFF
--- a/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
@@ -62,9 +62,9 @@ class MacroReadersImpl(_c: whitebox.Context) extends GenericDeriveImpl(_c) {
     val paramsTrees = params.map(_.map { p =>
       p.transformIfVarArg {
         p.default.map { d =>
-          q"${p.name.toTermName} = if (_root_.scala.scalajs.js.isUndefined(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName})) $d else ${getTypeclass(p.tpe)}.read(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName}.asInstanceOf[_root_.scala.scalajs.js.Object])"
+          q"if (_root_.scala.scalajs.js.isUndefined(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName})) $d else ${getTypeclass(p.tpe)}.read(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName}.asInstanceOf[_root_.scala.scalajs.js.Object])"
         }.getOrElse {
-          q"${p.name.toTermName} = ${getTypeclass(p.tpe)}.read(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName}.asInstanceOf[_root_.scala.scalajs.js.Object])"
+          q"${getTypeclass(p.tpe)}.read(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName}.asInstanceOf[_root_.scala.scalajs.js.Object])"
         }
       }
     })

--- a/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
@@ -62,9 +62,9 @@ class MacroReadersImpl(_c: whitebox.Context) extends GenericDeriveImpl(_c) {
     val paramsTrees = params.map(_.map { p =>
       p.transformIfVarArg {
         p.default.map { d =>
-          q"if (_root_.scala.scalajs.js.isUndefined(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName})) $d else ${getTypeclass(p.tpe)}.read(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName}.asInstanceOf[_root_.scala.scalajs.js.Object])"
+          q"${p.name.toTermName} = if (_root_.scala.scalajs.js.isUndefined(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName})) $d else ${getTypeclass(p.tpe)}.read(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName}.asInstanceOf[_root_.scala.scalajs.js.Object])"
         }.getOrElse {
-          q"${getTypeclass(p.tpe)}.read(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName}.asInstanceOf[_root_.scala.scalajs.js.Object])"
+          q"${p.name.toTermName} = ${getTypeclass(p.tpe)}.read(o.asInstanceOf[_root_.scala.scalajs.js.Dynamic].${p.name.toTermName}.asInstanceOf[_root_.scala.scalajs.js.Object])"
         }
       }
     })

--- a/readWrite/src/main/scala/slinky/readwrite/GenericDeriveImpl.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/GenericDeriveImpl.scala
@@ -122,7 +122,7 @@ abstract class GenericDeriveImpl(val c: whitebox.Context) { self =>
                 transformedValueType.substituteTypes(symbol.asType.typeParams, tTag.tpe.typeArgs),
                 if (p.asTerm.isParamWithDefault && companion != NoSymbol) {
                   val defaultTermName = "apply$default$" + (i + 1)
-                  Some(q"${c.parse(companion.fullName)}.${TermName(defaultTermName)}")
+                  Some(q"$companion.${TermName(defaultTermName)}")
                 } else None
               )
             })

--- a/tests/src/test/scala/slinky/core/ComponentTest.scala
+++ b/tests/src/test/scala/slinky/core/ComponentTest.scala
@@ -239,6 +239,19 @@ object TestUnderivable {
   }
 }
 
+object DefaultStateParamsComponent extends ComponentWrapper {
+  type Props = Unit
+  case class State(a: Int = 1)
+
+  class Def(jsProps: js.Object) extends Definition(jsProps) {
+    override def initialState = null
+
+    override def render(): ReactElement = {
+      null
+    }
+  }
+}
+
 class ComponentTest extends AsyncFunSuite {
   test("setState given function is applied") {
     val promise: Promise[Assertion] = Promise()


### PR DESCRIPTION
From testing with a much larger Slinky-based project.