### PR TITLE
Fix derived state and union writers in fullOptJS mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 + The `Option` writer now emits `null` instead of `js.undefined` for a value of `None` [PR #247](https://github.com/shadaj/slinky/pull/247)
 
 ### Bug Fixes
-+ Make the static lifecycle functions `getDerivedStateFromProps` and `getDerivedStateFromError` not working in `fullOptJS` mode [PR #248](https://github.com/shadaj/slinky/pull/248)
++ Make the static lifecycle functions `getDerivedStateFromProps` and `getDerivedStateFromError` work correctly in `fullOptJS` mode [PR #248](https://github.com/shadaj/slinky/pull/248)
 + Fix issues around state not updating when setting an `Option` to `None` in hot reloading mode [PR #247](https://github.com/shadaj/slinky/pull/247)
 + Fix the `js.|` reader/writer implementations to work correctly in `fullOptJS` mode [PR #248](https://github.com/shadaj/slinky/pull/248)
 + Support autoComplete attr for input and form elements [PR #225](https://github.com/shadaj/slinky/pull/225)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@
 
 ### Breaking Changes :warning:
 + The tags API has seen some major changes, please take a look at the separate section below for more details [PR #243](https://github.com/shadaj/slinky/pull/243)
++ Components using the static lifecycle functions `getDerivedStateFromProps` and `getDerivedStateFromError` must now override the functions with a `val` [PR #248](https://github.com/shadaj/slinky/pull/248)
 + The `React.forwardRef` function now takes a `FunctionalComponentTakingRef`, which can be creating by creating a functional component that takes an additional ref parameter: `FunctionalComponent((props, ref) => ...)` [PR #227](https://github.com/shadaj/slinky/pull/227)
 + The `ReactRef` type is no longer variant in its type parameters to increase type safety [PR #227](https://github.com/shadaj/slinky/pull/227)
 + Components will no longer have their `displayName` when built in `fullOptJS` mode, this results in a **~2.5% decrease in bundle size** and matches behavior with JS where names are obfuscated in production builds  [PR #217](https://github.com/shadaj/slinky/pull/217)
 + The `Option` writer now emits `null` instead of `js.undefined` for a value of `None` [PR #247](https://github.com/shadaj/slinky/pull/247)
 
 ### Bug Fixes
++ Make the static lifecycle functions `getDerivedStateFromProps` and `getDerivedStateFromError` not working in `fullOptJS` mode [PR #248](https://github.com/shadaj/slinky/pull/248)
 + Fix issues around state not updating when setting an `Option` to `None` in hot reloading mode [PR #247](https://github.com/shadaj/slinky/pull/247)
++ Fix the `js.|` reader/writer implementations to work correctly in `fullOptJS` mode [PR #248](https://github.com/shadaj/slinky/pull/248)
 + Support autoComplete attr for input and form elements [PR #225](https://github.com/shadaj/slinky/pull/225)
 + Fix capitalization of `rowSpan`/`colSpan` attribute (used to be `rowspan`/`colspan`) [PR #224](https://github.com/shadaj/slinky/pull/224)
 

--- a/core/src/main/scala/slinky/core/BaseComponentWrapper.scala
+++ b/core/src/main/scala/slinky/core/BaseComponentWrapper.scala
@@ -3,9 +3,11 @@ package slinky.core
 import slinky.core.facade.{React, ReactRaw, ReactElement, ReactRef}
 import slinky.readwrite.{Reader, Writer}
 
-import scala.language.experimental.macros
 import scala.scalajs.js
 import scala.scalajs.js.ConstructorTag
+import scala.scalajs.js.annotation.JSExport
+
+import scala.language.experimental.macros
 import scala.language.implicitConversions
 import scala.reflect.macros.whitebox
 
@@ -44,8 +46,9 @@ abstract class BaseComponentWrapper(sr: StateReaderProvider, sw: StateWriterProv
 
   type Definition <: js.Object
 
-  def getDerivedStateFromProps(props: Props, state: State): State = null.asInstanceOf[State]
-  def getDerivedStateFromError(error: js.Error): State = null.asInstanceOf[State]
+  val getDerivedStateFromProps: (Props, State) => State = null
+  
+  val getDerivedStateFromError: js.Error => State = null
 
   private[core] val hot_stateReader = sr.asInstanceOf[Reader[State]]
   private[core] val hot_stateWriter = sw.asInstanceOf[Writer[State]]
@@ -60,7 +63,7 @@ abstract class BaseComponentWrapper(sr: StateReaderProvider, sw: StateWriterProv
 
     constructor._base = this.asInstanceOf[js.Any]
 
-    if (this.asInstanceOf[js.Dynamic].getDerivedStateFromProps__O__O__O != BaseComponentWrapper.defaultGetDerivedStateFromProps) {
+    if (this.getDerivedStateFromProps != null) {
       constructor.getDerivedStateFromProps = ((props: js.Object, state: js.Object) => {
         val propsScala = if (js.typeOf(props) == "object" && props.hasOwnProperty("__")) {
           props.asInstanceOf[js.Dynamic].__.asInstanceOf[Props]
@@ -84,7 +87,7 @@ abstract class BaseComponentWrapper(sr: StateReaderProvider, sw: StateWriterProv
       }): js.Function2[js.Object, js.Object, js.Object]
     }
 
-    if (this.asInstanceOf[js.Dynamic].getDerivedStateFromError__sjs_js_Error__O != BaseComponentWrapper.defaultGetDerivedStateFromError) {
+    if (this.getDerivedStateFromError != null) {
       constructor.getDerivedStateFromError = ((error: js.Error) => {
         val newState = getDerivedStateFromError(error)
 
@@ -132,22 +135,6 @@ abstract class BaseComponentWrapper(sr: StateReaderProvider, sw: StateWriterProv
 }
 
 object BaseComponentWrapper {
-  private[BaseComponentWrapper] val defaultGetDerivedStateFromProps = {
-    new BaseComponentWrapper(null, null) {
-      override type Props = Unit
-      override type State = Unit
-      override type Def = Nothing
-    }.asInstanceOf[js.Dynamic].getDerivedStateFromProps__O__O__O
-  }
-
-  private[BaseComponentWrapper] val defaultGetDerivedStateFromError = {
-    new BaseComponentWrapper(null, null) {
-      override type Props = Unit
-      override type State = Unit
-      override type Def = Nothing
-    }.asInstanceOf[js.Dynamic].getDerivedStateFromError__sjs_js_Error__O
-  }
-
   implicit def proplessKeyAndRef[C <: BaseComponentWrapper { type Props = Unit }](c: C)(implicit stateWriter: Writer[c.State], stateReader: Reader[c.State], constructorTag: ConstructorTag[c.Def]): KeyAndRefAddingStage[c.Def] = {
     c.apply(())
   }

--- a/docs/public/docs/writing-components.md
+++ b/docs/public/docs/writing-components.md
@@ -138,15 +138,17 @@ class Def(jsProps: js.Object) extends Definition(jsProps) {
 ```
 
 ### Static Lifecycle Methods
-To use lifecycle methods defined in a static context, override the lifecycle method inside the companion object if using `@react` style or directly inside `ComponentWrapper` if using the non-annotation style.
+To use lifecycle methods defined in a static context, override the lifecycle function inside the companion object if using `@react` style or directly inside `ComponentWrapper` if using the non-annotation style.
+
+**Note:** for the static lifecycle methods, you must override with a `val`, not with a `def`.
 
 ```scala
 object MyComponent extends ComponentWrapper {
   case class Props(...)
   case class State(...)
   
-  override def getDerivedStateFromProps(nextProps: Props, prevState: State): State = { ... }
-  override def getDerivedStateFromError(error: js.Error): State = { ... }
+  override val getDerivedStateFromProps = (nextProps: Props, prevState: State) => { ... }
+  override val getDerivedStateFromError = (error: js.Error) => { ... }
 
   class Def(jsProps: js.Object) extends Definition(jsProps) {
     def render = { ... }
@@ -164,8 +166,8 @@ Or with the `@react` API:
 }
 
 object MyComponent {
-  override def getDerivedStateFromProps(nextProps: Props, prevState: State): State = { ... }
-  override def getDerivedStateFromError(error: js.Error): State = { ... }
+  override val getDerivedStateFromProps = (nextProps: Props, prevState: State) => { ... }
+  override val getDerivedStateFromError = (error: js.Error) => { ... }
 }
 ```
 

--- a/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
@@ -107,23 +107,77 @@ trait CoreReaders extends MacroReaders with FallbackReaders {
 
   implicit val unitReader: Reader[Unit] = _ => ()
 
-  implicit val stringReader: Reader[String] = _.asInstanceOf[String]
+  implicit val stringReader: Reader[String] = v => {
+    if (js.typeOf(v) == "string") {
+      v.asInstanceOf[String]
+    } else {
+      throw new IllegalArgumentException(s"The value $v is not a string")
+    }
+  }
 
-  implicit val charReader: Reader[Char] = _.asInstanceOf[String].head
+  implicit val charReader: Reader[Char] = v => {
+    if (js.typeOf(v) == "string") {
+      v.asInstanceOf[String].head
+    } else {
+      throw new IllegalArgumentException(s"The value $v is not a string (trying to get a char)")
+    }
+  }
 
-  implicit val byteReader: Reader[Byte] = _.asInstanceOf[Byte]
+  implicit val byteReader: Reader[Byte] = v => {
+    if (js.typeOf(v) == "number") {
+      v.asInstanceOf[Byte]
+    } else {
+      throw new IllegalArgumentException(s"The value $v is not a number")
+    }
+  }
 
-  implicit val shortReader: Reader[Short] = _.asInstanceOf[Short]
+  implicit val shortReader: Reader[Short] = v => {
+    if (js.typeOf(v) == "number") {
+      v.asInstanceOf[Short]
+    } else {
+      throw new IllegalArgumentException(s"The value $v is not a number")
+    }
+  }
 
-  implicit val intReader: Reader[Int] = _.asInstanceOf[Int]
+  implicit val intReader: Reader[Int] = v => {
+    if (js.typeOf(v) == "number") {
+      v.asInstanceOf[Int]
+    } else {
+      throw new IllegalArgumentException(s"The value $v is not a number")
+    }
+  }
 
-  implicit val longReader: Reader[Long] = _.asInstanceOf[String].toLong
+  implicit val longReader: Reader[Long] = v => {
+    if (js.typeOf(v) == "string") {
+      v.asInstanceOf[String].toLong
+    } else {
+      throw new IllegalArgumentException(s"The value $v is not a string (trying to get a long)")
+    }
+  }
 
-  implicit val booleanReader: Reader[Boolean] = _.asInstanceOf[Boolean]
+  implicit val booleanReader: Reader[Boolean] = v => {
+    if (js.typeOf(v) == "boolean") {
+      v.asInstanceOf[Boolean]
+    } else {
+      throw new IllegalArgumentException(s"The value $v is not a boolean")
+    }
+  }
 
-  implicit val doubleReader: Reader[Double] = _.asInstanceOf[Double]
+  implicit val doubleReader: Reader[Double] = v => {
+    if (js.typeOf(v) == "number") {
+      v.asInstanceOf[Double]
+    } else {
+      throw new IllegalArgumentException(s"The value $v is not a number")
+    }
+  }
 
-  implicit val floatReader: Reader[Float] = _.asInstanceOf[Float]
+  implicit val floatReader: Reader[Float] = v => {
+    if (js.typeOf(v) == "number") {
+      v.asInstanceOf[Float]
+    } else {
+      throw new IllegalArgumentException(s"The value $v is not a number")
+    }
+  }
 
   implicit def undefOrReader[T](implicit reader: Reader[T]): Reader[js.UndefOr[T]] = s => {
     if (js.isUndefined(s)) {

--- a/readWrite/src/main/scala/slinky/readwrite/CoreWriters.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreWriters.scala
@@ -126,18 +126,10 @@ trait CoreWriters extends MacroWriters with FallbackWriters {
     _.map(v => writer.write(v)).getOrElse(js.undefined.asInstanceOf[js.Object])
 
   implicit def unionWriter[A: ClassTag, B: ClassTag](implicit aWriter: Writer[A], bWriter: Writer[B]): Writer[A | B] = { v =>
-    try {
+    if (implicitly[ClassTag[A]].runtimeClass.isInstance(v)) {
       aWriter.write(v.asInstanceOf[A])
-    } catch {
-      case e: Throwable =>
-        try {
-          bWriter.write(v.asInstanceOf[B])
-        } catch {
-          case e2: Throwable =>
-            println("Neither writer for the union worked.")
-            e.printStackTrace()
-            throw e2
-        }
+    } else {
+      bWriter.write(v.asInstanceOf[B])
     }
   }
 

--- a/readWrite/src/main/scala/slinky/readwrite/CoreWriters.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreWriters.scala
@@ -126,10 +126,17 @@ trait CoreWriters extends MacroWriters with FallbackWriters {
     _.map(v => writer.write(v)).getOrElse(js.undefined.asInstanceOf[js.Object])
 
   implicit def unionWriter[A: ClassTag, B: ClassTag](implicit aWriter: Writer[A], bWriter: Writer[B]): Writer[A | B] = { v =>
-    if (implicitly[ClassTag[A]].runtimeClass.isInstance(v)) {
+    if (implicitly[ClassTag[A]].runtimeClass == v.getClass) {
       aWriter.write(v.asInstanceOf[A])
-    } else {
+    } else if (implicitly[ClassTag[B]].runtimeClass == v.getClass) {
       bWriter.write(v.asInstanceOf[B])
+    } else {
+      try {
+        aWriter.write(v.asInstanceOf[A])
+      } catch {
+        case _: Throwable =>
+          bWriter.write(v.asInstanceOf[B])
+      }
     }
   }
 

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -1,9 +1,20 @@
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSPlugin)
 
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.6-SNAP4" % Test
 
-npmDependencies in Test += "react" -> "16.8.1"
-npmDependencies in Test += "react-dom" -> "16.8.1"
 jsDependencies += RuntimeDOM % Test
+
+dependencyOverrides += "org.webjars.npm" % "js-tokens" % "3.0.2" % Test
+
+jsDependencies ++= Seq(
+  "org.webjars.npm" % "react" % "16.8.3" % Test / "umd/react.development.js"
+    minified "umd/react.production.min.js" commonJSName "React",
+  "org.webjars.npm" % "react-dom" % "16.8.3" % Test / "umd/react-dom.development.js"
+    minified "umd/react-dom.production.min.js" dependsOn "umd/react.development.js" commonJSName "ReactDOM",
+  "org.webjars.npm" % "react-dom" % "16.8.3" % Test / "umd/react-dom-test-utils.development.js"
+    minified "umd/react-dom-test-utils.production.min.js" dependsOn "umd/react-dom.development.js" commonJSName "ReactTestUtils",
+  "org.webjars.npm" % "react-dom" % "16.8.3" % Test / "umd/react-dom-server.browser.development.js"
+    minified  "umd/react-dom-server.browser.production.min.js" dependsOn "umd/react-dom.development.js" commonJSName "ReactDOMServer"
+)
 
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"

--- a/tests/src/test/scala/slinky/core/ComponentTest.scala
+++ b/tests/src/test/scala/slinky/core/ComponentTest.scala
@@ -183,7 +183,7 @@ object DerivedStateComponent extends ComponentWrapper {
   case class Props(num: Int, onValue: Int => Unit)
   type State = Int
 
-  override def getDerivedStateFromProps(nextProps: Props, prevState: State): State = {
+  override val getDerivedStateFromProps = (nextProps: Props, prevState: State) => {
     nextProps.num
   }
 
@@ -204,7 +204,7 @@ object DerivedStateFromErrorComponent extends ComponentWrapper {
   case class Props(onValue: Int => Unit)
   type State = Int
 
-  override def getDerivedStateFromError(e: js.Error): State = {
+  override val getDerivedStateFromError = (e: js.Error) => {
     123
   }
 

--- a/tests/src/test/scala/slinky/core/annotations/ReactAnnotatedComponentTest.scala
+++ b/tests/src/test/scala/slinky/core/annotations/ReactAnnotatedComponentTest.scala
@@ -184,7 +184,7 @@ object TakeValuesFromCompanionObject {
 }
 
 object DerivedStateComponent {
-  override def getDerivedStateFromProps(nextProps: Props, prevState: State): State = {
+  override val getDerivedStateFromProps = (nextProps: Props, prevState: State) => {
     nextProps.num
   }
 }


### PR DESCRIPTION
Turns out that testing in `fullOptJS` mode with Scala.js Bundler actually does nothing, and just tests with the `fastOptJS` results instead! This drops Scala.js Bundler for the test project (replace with WebJars) and gets all the unit tests to actually pass in `fullOptJS` mode.

Fixes #231