### PR TITLE
Correct parameter type in documentation

### DIFF
--- a/docs/public/docs/external-components.md
+++ b/docs/public/docs/external-components.md
@@ -16,7 +16,7 @@ object ReactRouterDOM extends js.Object {
 }
 
 @react object Route extends ExternalComponent {
-  case class Props(path: String, component: ReactComponentClass, exact: Boolean = false)
+  case class Props(path: String, component: ReactComponentClass[_], exact: Boolean = false)
   override val component = ReactRouterDOM.Route
 }
 


### PR DESCRIPTION
To avoid compile error `trait ReactComponentClass takes type parameters`