### PR TITLE
mutable map reader writer

### DIFF
--- a/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
@@ -2,14 +2,14 @@ package slinky.readwrite
 
 import scala.annotation.compileTimeOnly
 import CompatUtil._
+
+import scala.collection.mutable
 import scala.concurrent.Future
 import scala.scalajs.js
 import scala.scalajs.js.|
 import scala.concurrent.ExecutionContext.Implicits.global
-
 import scala.reflect.ClassTag
 import scala.reflect.macros.whitebox
-
 import scala.language.experimental.macros
 import scala.language.higherKinds
 
@@ -222,6 +222,9 @@ trait CoreReaders extends MacroReaders with FallbackReaders {
   implicit def mapReader[A, B](implicit abReader: Reader[(A, B)]): Reader[Map[A, B]] = o => {
     collectionReader[(A, B), Iterable].read(o).toMap
   }
+
+  implicit def mutableMapReader[T](implicit reader: Reader[T]): Reader[mutable.Map[String, T]] =
+    _.asInstanceOf[mutable.Map[String, T]]
 
   implicit val rangeReader: Reader[Range] = o => {
     val dyn = o.asInstanceOf[js.Dynamic]

--- a/readWrite/src/main/scala/slinky/readwrite/CoreWriters.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreWriters.scala
@@ -2,13 +2,13 @@ package slinky.readwrite
 
 import scala.annotation.compileTimeOnly
 import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 import scala.scalajs.js
 import scala.scalajs.js.|
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.reflect.macros.whitebox
-
 import scala.language.experimental.macros
 import scala.language.higherKinds
 
@@ -170,6 +170,11 @@ trait CoreWriters extends MacroWriters with FallbackWriters {
 
   implicit def mapWriter[A, B](implicit abWriter: Writer[(A, B)]): Writer[Map[A, B]] = s => {
     collectionWriter[(A, B), Iterable].write(s)
+  }
+
+  implicit def mutableMapWriter[T](implicit writer: Writer[T]): Writer[mutable.Map[String, T]] = {
+    import scala.scalajs.js.JSConverters._
+    _.toJSDictionary.asInstanceOf[js.Object]
   }
 
   implicit val rangeWriter: Writer[Range] = r => {

--- a/tests/src/test/scala/slinky/core/ReaderWriterTest.scala
+++ b/tests/src/test/scala/slinky/core/ReaderWriterTest.scala
@@ -3,6 +3,7 @@ package slinky.core
 import slinky.readwrite.{Reader, WithRaw, Writer}
 import org.scalatest.FunSuite
 
+import scala.collection.mutable
 import scala.scalajs.js
 import scala.scalajs.js.|
 
@@ -171,6 +172,10 @@ class ReaderWriterTest extends FunSuite {
 
   test("Read/write - maps") {
     readWrittenSame(Map(1 -> 2, 3 -> 4))
+  }
+
+  test("Read/write - mutable maps") {
+    readWrittenSame(mutable.Map("1" -> 2, "3" -> 4))
   }
 
   test("Read/write - ranges (inclusive)") {


### PR DESCRIPTION
added reader and writer for scala mutable maps to convert to javascript Dictionaries, following scalajs type conversions

I'm not familiar with environment setup, so when I run unit tests from root (`sbt tests/test`) I get confusing error:
> [info] Fast optimizing /proj/memory/jenkins/compilerdev/me/git/slinky/tests/target/scala-2.12/tests-test-fastopt.js
internal/modules/cjs/loader.js:583
    throw err;
    ^

> Error: Cannot find module 'jsdom'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at [stdin]:111:15
    at [stdin]:196:3
    at Script.runInThisContext (vm.js:96:20)
    at Object.runInThisContext (vm.js:303:38)
    at Object.<anonymous> ([stdin]-wrapper:6:22)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
[error] org.scalajs.jsenv.ExternalJSEnv$NonZeroExitException: Node.js with JSDOM exited with code 1
[error]         at org.scalajs.jsenv.ExternalJSEnv$AbstractExtRunner.waitForVM(ExternalJSEnv.scala:126)
[error]         at org.scalajs.jsenv.ExternalJSEnv$AsyncExtRunner$$anon$1.$anonfun$run$2(ExternalJSEnv.scala:191)
[error]         at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[error]         at scala.util.Try$.apply(Try.scala:209)
[error]         at org.scalajs.jsenv.ExternalJSEnv$AsyncExtRunner$$anon$1.run(ExternalJSEnv.scala:191)
[error] (tests / Test / loadedTestFrameworks) org.scalajs.jsenv.ExternalJSEnv$NonZeroExitException: Node.js with JSDOM exited with code 1
[error] Total time: 116 s, completed Jul 15, 2019 12:50:24 PM
