### PR TITLE
Add Keyboard api facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bug Fixes
 + Support `useCallback` with a function that takes arguments [PR #290](https://github.com/shadaj/slinky/pull/290)
 + Fix issues around using ReactElements within first-order types e.g. Map, List [PR #285](https://github.com/shadaj/slinky/pull/285)
++ Support [React Native's Keyboard API](https://facebook.github.io/react-native/docs/keyboard) via a scalajs facade [PR #293](https://github.com/shadaj/slinky/pull/293)
 
 ## [v0.6.2](https://slinky.dev)
 ### Highlights :tada:

--- a/native/src/main/scala/slinky/native/Keyboard.scala
+++ b/native/src/main/scala/slinky/native/Keyboard.scala
@@ -6,9 +6,9 @@ import scala.scalajs.js.annotation.JSImport
 @js.native
 @JSImport("react-native", "Keyboard")
 object Keyboard extends js.Object {
-  def addListener(eventName: String, callBack: () => Unit): Unit = js.native
+  def addListener(eventName: String, callBack: js.Function0[Unit]): Unit = js.native
 
-  def removeListener(eventName: String, callBack: () => Unit): Unit = js.native
+  def removeListener(eventName: String, callBack: js.Function0[Unit]): Unit = js.native
 
   def removeAllListeners(eventName: String): Unit = js.native
 

--- a/native/src/main/scala/slinky/native/Keyboard.scala
+++ b/native/src/main/scala/slinky/native/Keyboard.scala
@@ -1,0 +1,16 @@
+package slinky.native
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("react-native", "Keyboard")
+object Keyboard extends js.Object {
+  def addListener(eventName: String, callBack: () => Unit): Unit = js.native
+
+  def removeListener(eventName: String, callBack: () => Unit): Unit = js.native
+
+  def removeAllListeners(eventName: String): Unit = js.native
+
+  def dismiss(): Unit = js.native
+}


### PR DESCRIPTION
Facades {Keyboard} from 'react-native'

With this patch, one can write something like the following, and get keyboard dismissing behavior when the user clicks in the background.

```scala
  def KeyboardDismissingView(mods: TagMod[Nothing]*) = TouchableHighlight(
    onPress = () => Keyboard.dismiss(),  // Keyboard.dismiss() added by this PR.
    style = literal(
      flex = 1,
    ),
  )(mods: _*)
```

