### PR TITLE
Fix false "discarded non-Unit value" errors on @react classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 + Fix crashes when calling `setState` on a component with `Props` set to some subtype of `Function1` [PR #295](https://github.com/shadaj/slinky/pull/295)
 + Support `useCallback` with a function that takes arguments [PR #290](https://github.com/shadaj/slinky/pull/290)
++ Fix false warnings on `@react` classes if `-Ywarn-value-discard` scalac option was used [PR #296](https://github.com/shadaj/slinky/pull/296)
 
 ## [v0.6.2](https://slinky.dev)
 ### Highlights :tada:

--- a/core/src/main/scala/slinky/core/annotations/react.scala
+++ b/core/src/main/scala/slinky/core/annotations/react.scala
@@ -100,6 +100,7 @@ object ReactMacrosImpl {
                 null.asInstanceOf[Props]
                 null.asInstanceOf[State]
                 null.asInstanceOf[Snapshot]
+                ()
               })
               ..${stats.filterNot(s => s == propsDefinition || s == stateDefinition.orNull || s == snapshotDefinition.orNull)}
             }"""


### PR DESCRIPTION
Macro-generated class body emitted calls to `bump`, which accepted `=> Unit`.

Since last expression of that call was `null.asInstanceOf[Snapshot]`, Scala would auto-discard that value, and emit a warning if user has -Ywarn-value-discard. That means a false positive warning for each @react class.

Explicitly returning () in the block fixes that for scalac lint.