### PR TITLE
[WIP] Add scalacoptions to catch potential errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,7 @@ lazy val hot = project.settings(macroAnnotationSettings, librarySettings, crossS
 
 lazy val scalajsReactInterop = project.settings(macroAnnotationSettings, librarySettings).dependsOn(core, web % Test)
 
-lazy val tests = project.settings(macroAnnotationSettings, crossScalaSettings).dependsOn(core, web, hot)
+lazy val tests = project.settings(macroAnnotationSettings, crossScalaSettings).disablePlugins(TpolecatPlugin).dependsOn(core, web, hot)
 
 lazy val docsMacros = project.settings(macroAnnotationSettings).dependsOn(web, hot)
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,11 @@ def priorTo2_13(scalaVersion: String): Boolean =
     case _                              => false
   }
 
+val misbehavingScalacOptions = Set(
+  "-Ywarn-dead-code", "-Wdead-code",
+  "-Ywarn-unused:params", "-Wunused:params",
+  "-Ywarn-unused:patvars", "-Wunused:patvars"
+)
 
 lazy val librarySettings = Seq(
   scalacOptions += {
@@ -54,6 +59,7 @@ lazy val librarySettings = Seq(
     val g = "https://raw.githubusercontent.com/shadaj/slinky"
     s"-P:scalajs:mapSourceURI:$a->$g/$githubVersion/${baseDirectory.value.getName}/"
   },
+  scalacOptions ~= (_.filterNot(misbehavingScalacOptions))
 )
 
 addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@ organization in ThisBuild := "me.shadaj"
 
 scalaVersion in ThisBuild := "2.12.8"
 
-scalacOptions in ThisBuild ++= Seq("-feature", "-deprecation")
-
 lazy val slinky = project.in(file(".")).aggregate(
   readWrite,
   core,
@@ -36,32 +34,6 @@ lazy val crossScalaSettings = Seq(
   }
 )
 
-def commonScalacOptions(scalaVersion: String) = {
-  Seq(
-    "-encoding",
-    "UTF-8",
-    "-feature",
-    "-language:existentials",
-    "-language:higherKinds",
-    "-language:implicitConversions",
-    "-language:experimental.macros",
-    "-unchecked",
-    "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard"
-  ) ++ (if (priorTo2_13(scalaVersion)) {
-    Seq(
-      "-Xfuture",
-      "-Yno-adapted-args",
-      "-deprecation",
-      "-Xfatal-warnings" // fails Scaladoc compilation on 2.13
-    )
-  } else {
-    Seq(
-      "-Ymacro-annotations"
-    )
-  })
-}
-
 def priorTo2_13(scalaVersion: String): Boolean =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, minor)) if minor < 13 => true
@@ -82,7 +54,6 @@ lazy val librarySettings = Seq(
     val g = "https://raw.githubusercontent.com/shadaj/slinky"
     s"-P:scalajs:mapSourceURI:$a->$g/$githubVersion/${baseDirectory.value.getName}/"
   },
-  scalacOptions ++= commonScalacOptions(scalaVersion.value)
 )
 
 addCommandAlias(

--- a/core/src/main/scala/slinky/core/BaseComponentWrapper.scala
+++ b/core/src/main/scala/slinky/core/BaseComponentWrapper.scala
@@ -1,14 +1,11 @@
 package slinky.core
 
-import slinky.core.facade.{React, ReactRaw, ReactElement, ReactRef}
+import slinky.core.facade.{ReactRaw, ReactElement, ReactRef}
 import slinky.readwrite.{Reader, Writer}
 
 import scala.scalajs.js
 import scala.scalajs.js.ConstructorTag
-import scala.scalajs.js.annotation.JSExport
 
-import scala.language.experimental.macros
-import scala.language.implicitConversions
 import scala.reflect.macros.whitebox
 
 final class KeyAndRefAddingStage[D](private val args: js.Array[js.Any]) extends AnyVal {

--- a/core/src/main/scala/slinky/core/BaseComponentWrapper.scala
+++ b/core/src/main/scala/slinky/core/BaseComponentWrapper.scala
@@ -68,7 +68,7 @@ abstract class BaseComponentWrapper(sr: StateReaderProvider, sw: StateWriterProv
   type Definition <: js.Object
 
   val getDerivedStateFromProps: (Props, State) => State = null
-  
+
   val getDerivedStateFromError: js.Error => State = null
 
   private[core] val hot_stateReader = sr.asInstanceOf[Reader[State]]
@@ -160,7 +160,7 @@ abstract class BaseComponentWrapper(sr: StateReaderProvider, sw: StateWriterProv
 }
 
 object BaseComponentWrapper {
-  implicit def proplessKeyAndRef[C <: BaseComponentWrapper { type Props = Unit }](c: C)(implicit stateWriter: Writer[c.State], stateReader: Reader[c.State], constructorTag: ConstructorTag[c.Def]): KeyAndRefAddingStage[c.Def] = {
+  implicit def proplessKeyAndRef[C <: BaseComponentWrapper { type Props = Unit }](c: C)(implicit constructorTag: ConstructorTag[c.Def]): KeyAndRefAddingStage[c.Def] = {
     c.apply(())
   }
 

--- a/core/src/main/scala/slinky/core/ComponentWrapper.scala
+++ b/core/src/main/scala/slinky/core/ComponentWrapper.scala
@@ -1,7 +1,5 @@
 package slinky.core
 
-import scala.language.implicitConversions
-
 abstract class ComponentWrapper(implicit sr: StateReaderProvider, sw: StateWriterProvider) extends BaseComponentWrapper(sr, sw) {
   override type Definition = DefinitionBase[Props, State, Snapshot]
 }

--- a/core/src/main/scala/slinky/core/ExternalComponent.scala
+++ b/core/src/main/scala/slinky/core/ExternalComponent.scala
@@ -1,12 +1,10 @@
 package slinky.core
 
-import slinky.core.facade.{React, ReactRaw, ReactElement, ReactRef}
+import slinky.core.facade.{ReactRaw, ReactElement, ReactRef}
 import slinky.readwrite.Writer
 
-import scala.language.implicitConversions
 import scala.scalajs.js
 import scala.scalajs.js.|
-import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
 final class BuildingComponent[E, R <: js.Object](private val args: js.Array[js.Any]) extends AnyVal {

--- a/core/src/main/scala/slinky/core/FunctionalComponent.scala
+++ b/core/src/main/scala/slinky/core/FunctionalComponent.scala
@@ -37,7 +37,7 @@ object KeyAddingStage {
 }
 
 final class FunctionalComponent[P] private[core](private[core] val component: js.Function) extends AnyVal {
-  type Props = P
+  type Props = js.UndefOr[P]
   type Result = KeyAddingStage
 
   private[core] def componentWithReader(propsReader: Reader[P]) = {
@@ -45,7 +45,7 @@ final class FunctionalComponent[P] private[core](private[core] val component: js
     component
   }
 
-  @inline def apply(props: P): KeyAddingStage = {
+  @inline def apply(props: js.UndefOr[P] = js.undefined): KeyAddingStage = {
     new KeyAddingStage(js.Array(component, js.Dynamic.literal(
       __ = props.asInstanceOf[js.Any]
     )))
@@ -53,7 +53,7 @@ final class FunctionalComponent[P] private[core](private[core] val component: js
 }
 
 final class FunctionalComponentTakingRef[P, R] private[core](private[core] val component: js.Function) extends AnyVal {
-  type Props = P
+  type Props = js.UndefOr[P]
   type Result = KeyAddingStage
 
   private[core] def componentWithReader(propsReader: Reader[P]) = {
@@ -61,7 +61,7 @@ final class FunctionalComponentTakingRef[P, R] private[core](private[core] val c
     component
   }
 
-  @inline def apply(props: P): KeyAddingStage = {
+  @inline def apply(props: js.UndefOr[P] = js.undefined): KeyAddingStage = {
     new KeyAddingStage(js.Array(component, js.Dynamic.literal(
       __ = props.asInstanceOf[js.Any]
     )))
@@ -69,7 +69,7 @@ final class FunctionalComponentTakingRef[P, R] private[core](private[core] val c
 }
 
 final class FunctionalComponentForwardedRef[P, R] private[core](private[core] val component: js.Any) extends AnyVal {
-  type Props = P
+  type Props = js.UndefOr[P]
   type Result = KeyAndRefAddingStage[R]
 
   private[core] def componentWithReader(propsReader: Reader[P]) = {
@@ -77,7 +77,7 @@ final class FunctionalComponentForwardedRef[P, R] private[core](private[core] va
     component
   }
 
-  @inline def apply(props: P): KeyAndRefAddingStage[R] = {
+  @inline def apply(props: js.UndefOr[P] = js.undefined): KeyAndRefAddingStage[R] = {
     new KeyAndRefAddingStage[R](js.Array(
       component,
       js.Dynamic.literal(

--- a/core/src/main/scala/slinky/core/FunctionalComponent.scala
+++ b/core/src/main/scala/slinky/core/FunctionalComponent.scala
@@ -1,13 +1,10 @@
 package slinky.core
 
 import slinky.readwrite.Reader
-import slinky.core.facade.{React, ReactRaw, ReactElement, ReactRef}
+import slinky.core.facade.{ReactRaw, ReactElement, ReactRef}
 import scala.scalajs.js
 
 import scala.reflect.macros.whitebox
-import scala.language.experimental.macros
-
-import scala.language.implicitConversions
 
 final class KeyAddingStage(private val args: js.Array[js.Any]) extends AnyVal {
   @inline def withKey(key: String): ReactElement = {

--- a/core/src/main/scala/slinky/core/ReactComponentClass.scala
+++ b/core/src/main/scala/slinky/core/ReactComponentClass.scala
@@ -5,8 +5,6 @@ import slinky.readwrite.Reader
 import scala.scalajs.js
 import scala.scalajs.js.ConstructorTag
 
-import scala.language.implicitConversions
-
 @js.native
 trait ReactComponentClass[P] extends js.Object
 

--- a/core/src/main/scala/slinky/core/TagComponent.scala
+++ b/core/src/main/scala/slinky/core/TagComponent.scala
@@ -1,11 +1,8 @@
 package slinky.core
 
-import slinky.core.facade.{React, ReactElement, ReactRaw}
+import slinky.core.facade.{ReactElement, ReactRaw}
 
-import scala.language.implicitConversions
 import scala.scalajs.js
-import scala.scalajs.js.{Dictionary, JSON}
-import scala.language.higherKinds
 
 trait Tag extends Any {
   type tagType <: TagElement

--- a/core/src/main/scala/slinky/core/annotations/react.scala
+++ b/core/src/main/scala/slinky/core/annotations/react.scala
@@ -3,7 +3,6 @@ package slinky.core.annotations
 import slinky.core._
 
 import scala.annotation.compileTimeOnly
-import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 import scala.scalajs.js
 

--- a/core/src/main/scala/slinky/core/facade/React.scala
+++ b/core/src/main/scala/slinky/core/facade/React.scala
@@ -1,14 +1,12 @@
 package slinky.core.facade
 
 import slinky.core._
-import slinky.readwrite.{ObjectOrWritten, Reader, Writer}
 
 import scala.scalajs.js
 import js.|
 import scala.annotation.unchecked.uncheckedVariance
 import scala.scalajs.js.annotation.{JSImport, JSName}
 import scala.scalajs.js.JSConverters._
-import scala.language.implicitConversions
 
 @js.native
 trait ReactElement extends js.Object with ReactElementMod

--- a/core/src/main/scala/slinky/core/facade/ReactContext.scala
+++ b/core/src/main/scala/slinky/core/facade/ReactContext.scala
@@ -1,10 +1,9 @@
 package slinky.core.facade
 
 import slinky.core.{BuildingComponent, ExternalComponent, ExternalPropsWriterProvider}
-import slinky.readwrite.{Reader, Writer}
+import slinky.readwrite.Writer
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSName
 import scala.scalajs.js.|
 
 @js.native

--- a/docs/src/main/scala/slinky/docs/CodeExample.scala
+++ b/docs/src/main/scala/slinky/docs/CodeExample.scala
@@ -7,7 +7,6 @@ import slinky.web.html._
 
 import scala.scalajs.js
 import scala.scalajs.js.Dynamic.literal
-import scala.language.experimental.macros
 
 @react object CodeExampleInternal {
   case class Props(codeText: String, demoElement: ReactElement)

--- a/docs/src/main/scala/slinky/docs/DocsGroup.scala
+++ b/docs/src/main/scala/slinky/docs/DocsGroup.scala
@@ -2,7 +2,6 @@ package slinky.docs
 
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
-import slinky.core.facade.ReactElement
 import slinky.reactrouter.NavLink
 import slinky.web.html._
 

--- a/docs/src/main/scala/slinky/docs/DocsPage.scala
+++ b/docs/src/main/scala/slinky/docs/DocsPage.scala
@@ -1,6 +1,6 @@
 package slinky.docs
 
-import slinky.core.{Component, StatelessComponent, FunctionalComponent, ReactComponentClass}
+import slinky.core.{FunctionalComponent, ReactComponentClass}
 import slinky.core.annotations.react
 import slinky.core.facade.{Fragment, ReactElement}
 import slinky.core.facade.Hooks._

--- a/docs/src/main/scala/slinky/docs/Main.scala
+++ b/docs/src/main/scala/slinky/docs/Main.scala
@@ -80,6 +80,7 @@ object Main {
       ),
       container
     )
+    ()
   }
 
   var isSSR = false
@@ -125,5 +126,6 @@ object Main {
       ),
       container
     )
+    ()
   }
 }

--- a/docs/src/main/scala/slinky/docs/Navbar.scala
+++ b/docs/src/main/scala/slinky/docs/Navbar.scala
@@ -2,7 +2,6 @@ package slinky.docs
 
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
-import slinky.core.facade.ReactElement
 import slinky.docs.homepage.SlinkyHorizontalLogo
 import slinky.reactrouter.Link
 import slinky.web.html._

--- a/docs/src/main/scala/slinky/docs/SyntaxHighlighter.scala
+++ b/docs/src/main/scala/slinky/docs/SyntaxHighlighter.scala
@@ -4,8 +4,7 @@ import slinky.core.ExternalComponent
 import slinky.core.annotations.react
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.{JSImport, JSName}
-import scala.scalajs.js.|
+import scala.scalajs.js.annotation.JSImport
 
 @js.native
 @JSImport("react-syntax-highlighter/light", JSImport.Default)

--- a/docs/src/main/scala/slinky/docs/homepage/Examples.scala
+++ b/docs/src/main/scala/slinky/docs/homepage/Examples.scala
@@ -2,7 +2,6 @@ package slinky.docs.homepage
 
 import slinky.core.annotations.react
 import slinky.core.{FunctionalComponent}
-import slinky.core.facade.ReactElement
 import slinky.docs.CodeExample
 import slinky.web.html._
 

--- a/docs/src/main/scala/slinky/docs/homepage/Homepage.scala
+++ b/docs/src/main/scala/slinky/docs/homepage/Homepage.scala
@@ -1,8 +1,8 @@
 package slinky.docs.homepage
 
-import slinky.core.{Component, StatelessComponent, StatelessComponentWrapper}
+import slinky.core.StatelessComponent
 import slinky.core.annotations.react
-import slinky.docs.{MainPageContent, Navbar}
+import slinky.docs.MainPageContent
 import slinky.web.html._
 
 import scala.scalajs.js

--- a/docs/src/main/scala/slinky/docs/homepage/Jumbotron.scala
+++ b/docs/src/main/scala/slinky/docs/homepage/Jumbotron.scala
@@ -2,7 +2,6 @@ package slinky.docs.homepage
 
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
-import slinky.core.facade.ReactElement
 import slinky.reactrouter.Link
 import slinky.web.html._
 

--- a/generator/src/main/scala/slinky/generator/Generator.scala
+++ b/generator/src/main/scala/slinky/generator/Generator.scala
@@ -48,7 +48,7 @@ object Generator extends App {
       symbols.find(_._1 == Utils.identifierFor(attr.attributeName)) match {
         case Some(o@(_, (tags, None))) =>
           symbols - o + ((Utils.identifierFor(attr.attributeName), (tags, Some(attr))))
-        case None =>
+        case _ =>
           symbols + ((Utils.identifierFor(attr.attributeName), (None, Some(attr))))
       }
     }

--- a/generator/src/main/scala/slinky/generator/Generator.scala
+++ b/generator/src/main/scala/slinky/generator/Generator.scala
@@ -66,7 +66,6 @@ object Generator extends App {
       }
 
       val attrsGen = attrs.toList.flatMap { a =>
-        val compatibles = a.compatibleTags.map(ts => ts.map(n => extracted.tags.find(_.tagName == n).get)).getOrElse(extracted.tags)
         val noEvent = s"""@inline def :=(v: () => Unit) = new AttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)
                          |@inline def :=(v: Option[() => Unit]) = new OptionalAttrPair[_${symbolWithoutEscape}_attr.type]("${a.attributeName}", v)""".stripMargin
         val base = (if (eventToSynthetic.contains(a.attributeType)) {

--- a/generator/src/main/scala/slinky/generator/Generator.scala
+++ b/generator/src/main/scala/slinky/generator/Generator.scala
@@ -40,7 +40,11 @@ object Generator extends App {
         a.copy(compatibleTags = a.compatibleTags.map(_ :+ "*")))
     )
 
-    val allSymbols = extracted.attributes.foldLeft(extracted.tags.map(t => Utils.identifierFor(t.tagName) -> (Some(t): Option[Tag], None: Option[Attribute])).toSet) { case (symbols, attr) =>
+    val allSymbols = extracted.attributes.foldLeft(
+      extracted.tags.map { t =>
+        Utils.identifierFor(t.tagName) -> ((Some(t): Option[Tag], None: Option[Attribute]))
+      }.toSet
+    ){ case (symbols, attr) =>
       symbols.find(_._1 == Utils.identifierFor(attr.attributeName)) match {
         case Some(o@(_, (tags, None))) =>
           symbols - o + ((Utils.identifierFor(attr.attributeName), (tags, Some(attr))))

--- a/generator/src/main/scala/slinky/generator/MDN.scala
+++ b/generator/src/main/scala/slinky/generator/MDN.scala
@@ -144,7 +144,7 @@ object MDN extends TagsProvider {
         val children = dl.children.toList
         val attrsAndDocs = children.foldLeft(Seq.empty[(String, String)]) { (acc, cur) =>
           if (cur.tagName == "dt") {
-            acc :+ (cur >> text("code"), "")
+            acc :+ ((cur >> text("code"), ""))
           } else {
             acc.init :+ acc.last.copy(_2 = if (acc.last._2.isEmpty) cur.innerHtml else acc.last._2 + " " + cur.innerHtml)
           }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")
 
 addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.3.0")
+
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.10")

--- a/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreReaders.scala
@@ -10,9 +10,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.reflect.ClassTag
 import scala.reflect.macros.whitebox
 
-import scala.language.experimental.macros
-import scala.language.higherKinds
-
 @compileTimeOnly("Deferred readers are used to handle recursive structures")
 final class DeferredReader[T, Term] extends Reader[T] {
   override protected def forceRead(o: js.Object): T = throw new Exception

--- a/readWrite/src/main/scala/slinky/readwrite/CoreWriters.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/CoreWriters.scala
@@ -1,16 +1,12 @@
 package slinky.readwrite
 
 import scala.annotation.compileTimeOnly
-import scala.collection.generic.CanBuildFrom
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 import scala.scalajs.js
 import scala.scalajs.js.|
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.reflect.macros.whitebox
-
-import scala.language.experimental.macros
-import scala.language.higherKinds
 
 @compileTimeOnly("Deferred writers are used to handle recursive structures")
 final class DeferredWriter[T, Term] extends Writer[T] {

--- a/readWrite/src/main/scala/slinky/readwrite/ObjectOrWritten.scala
+++ b/readWrite/src/main/scala/slinky/readwrite/ObjectOrWritten.scala
@@ -1,6 +1,5 @@
 package slinky.readwrite
 
-import scala.language.{higherKinds, implicitConversions}
 import scala.scalajs.js
 
 @js.native

--- a/tests/src/test/scala/slinky/core/ComponentReturnTypeTests.scala
+++ b/tests/src/test/scala/slinky/core/ComponentReturnTypeTests.scala
@@ -10,6 +10,7 @@ class ComponentReturnTypeTests extends FunSuite {
   def testElement(elem: ReactElement): Unit = {
     assert((div(elem): ReactElement) != null) // test use in another element
     ReactDOM.render(div(elem), dom.document.createElement("div")) // test rendering to DOM
+    ()
   }
 
   test("Components can return - arrays") {

--- a/tests/src/test/scala/slinky/core/ComponentTest.scala
+++ b/tests/src/test/scala/slinky/core/ComponentTest.scala
@@ -21,7 +21,7 @@ object TestComponent extends ComponentWrapper {
     }
 
     override def componentDidMount(): Unit = {
-      setState((s, p) => {
+      setState((s, _) => {
         s + 1
       })
     }

--- a/tests/src/test/scala/slinky/core/ComponentTest.scala
+++ b/tests/src/test/scala/slinky/core/ComponentTest.scala
@@ -37,7 +37,7 @@ object TestComponentExtraApply extends ComponentWrapper {
   type State = Int
 
   class Def(jsProps: js.Object) extends Definition(jsProps) {
-    override def initialState(): Int = 0
+    override def initialState: Int = 0
 
     override def componentWillUpdate(nextProps: Props, nextState: Int): Unit = {
       props.apply(nextState)

--- a/tests/src/test/scala/slinky/core/HooksComponentTest.scala
+++ b/tests/src/test/scala/slinky/core/HooksComponentTest.scala
@@ -19,7 +19,7 @@ class HooksComponentTest extends AsyncFunSuite {
   test("Can render a functional component with useState hook") {
     val container = document.createElement("div")
     val component = FunctionalComponent[Int] { props =>
-      val (state, setState) = useState("hello")
+      val (state, _) = useState("hello")
       state + props
     }
     
@@ -180,7 +180,7 @@ class HooksComponentTest extends AsyncFunSuite {
   test("useContext hook gets context value") {
     val container = document.createElement("div")
     val context = React.createContext("")
-    val component = FunctionalComponent[Unit] { props =>
+    val component = FunctionalComponent[Unit] { _ =>
       val ctx = useContext(context)
       ctx
     }
@@ -198,7 +198,7 @@ class HooksComponentTest extends AsyncFunSuite {
     var doDispatch: Int => Unit = null
     val promise: Promise[Assertion] = Promise()
 
-    val component = FunctionalComponent[Unit] { props =>
+    val component = FunctionalComponent[Unit] { _ =>
       val (state, dispatch) = useReducer((s: String, a: Int) => {
         a.toString
       }, "")

--- a/tests/src/test/scala/slinky/core/annotations/ReactAnnotatedComponentTest.scala
+++ b/tests/src/test/scala/slinky/core/annotations/ReactAnnotatedComponentTest.scala
@@ -22,7 +22,7 @@ import scala.util.Try
   }
 
   override def componentDidMount(): Unit = {
-    setState((s, p) => {
+    setState((s, _) => {
       s + 1
     })
   }
@@ -39,7 +39,7 @@ import scala.util.Try
   override def initialState: Int = 0
 
   override def componentDidMount(): Unit = {
-    setState((s, p) => {
+    setState((s, _) => {
       s + 1
     }, () => {
       props.apply(state)
@@ -186,7 +186,7 @@ object TakeValuesFromCompanionObject {
 }
 
 object DerivedStateComponent {
-  override val getDerivedStateFromProps = (nextProps: Props, prevState: State) => {
+  override val getDerivedStateFromProps = (nextProps: Props, _: State) => {
     nextProps.num
   }
 }

--- a/tests/src/test/scala/slinky/core/annotations/ReactAnnotatedFunctionalComponentTest.scala
+++ b/tests/src/test/scala/slinky/core/annotations/ReactAnnotatedFunctionalComponentTest.scala
@@ -1,16 +1,11 @@
 package slinky.core.annotations
 
 import slinky.core.FunctionalComponent
-import slinky.core.facade.ReactElement
 
 import slinky.web.ReactDOM
-import slinky.web.html.div
 
 import org.scalajs.dom
-import org.scalatest.{Assertion, AsyncFunSuite}
-
-import scala.concurrent.Promise
-import scala.scalajs.js
+import org.scalatest.AsyncFunSuite
 
 @react object SimpleFunctionalComponent {
   case class Props[T](in: Seq[T])

--- a/web/src/main/scala/slinky/web/SyntheticCompositionEvent.scala
+++ b/web/src/main/scala/slinky/web/SyntheticCompositionEvent.scala
@@ -3,7 +3,7 @@ package slinky.web
 import slinky.core.SyntheticEvent
 
 import scala.scalajs.js
-import org.scalajs.dom.{CompositionEvent, DataTransfer}
+import org.scalajs.dom.CompositionEvent
 
 // https://reactjs.org/docs/events.html?#composition-events
 @js.native trait SyntheticCompositionEvent[+TargetType] extends SyntheticEvent[TargetType, CompositionEvent] {

--- a/web/src/main/scala/slinky/web/SyntheticPointerEvent.scala
+++ b/web/src/main/scala/slinky/web/SyntheticPointerEvent.scala
@@ -3,7 +3,7 @@ package slinky.web
 import slinky.core.SyntheticEvent
 
 import scala.scalajs.js
-import org.scalajs.dom.{PointerEvent, EventTarget}
+import org.scalajs.dom.PointerEvent
 
 // https://reactjs.org/docs/events.html#pointer-events
 @js.native trait SyntheticPointerEvent[+TargetType] extends SyntheticEvent[TargetType, PointerEvent] {


### PR DESCRIPTION
This adds this popular [scalac options plugin](https://github.com/DavidGregory084/sbt-tpolecat) to manage settings across scala versions. I tried to separate each type of fixed new warning into different commits, expecting you'll squash into one if merged.

The most ~~annoying~~ substantial of these changes is 97ae4bc, where the Generator is updated to only output the imports necessary for each file.