### PR TITLE
Fix build and testing in Windows

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -24,6 +24,30 @@ jobs:
       run: sbt ";scalajsReactInterop/test; + tests/test; + native/test"
     - name: Test with SBT (fullopt)
       run: sbt ";set scalaJSStage in Global := FullOptStage; scalajsReactInterop/test; + tests/test; + native/test"
+  test-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Configure git to disable Windows line feeds
+        run: "git config --global core.autocrlf false"
+        shell: bash
+      - uses: actions/checkout@master
+      # Pre-installed SBT on Windows-runner is unstable so use more polished 3rd-party action olafurpg/setup-scala.
+      - name: Set up JDK 1.8 and SBT
+        uses: olafurpg/setup-scala@v7
+        with:
+          java-version: 1.8
+      - name: Install NPM Dependencies
+        run: npm install; cd native; npm install; cd ..
+        shell: bash
+      - name: Test with SBT (fastopt)
+        run: sbt ";scalajsReactInterop/test; + tests/test; + native/test"
+        shell: bash
+      - name: Test with SBT (fullopt)
+        run: sbt ";set scalaJSStage in Global := FullOptStage; scalajsReactInterop/test; + tests/test; + native/test"
+        shell: bash
   build-docs:
     runs-on: ubuntu-latest
 
@@ -53,6 +77,8 @@ jobs:
     - name: Build IntelliJ Plugin
       run: sbt coreIntellijSupport/updateIntellij coreIntellijSupport/compile
   publish:
+    # Currently publication doesn't depend on testing results for Windows platform, since primary developers use Linux,
+    # but it may be changed in the future.
     needs: [test, build-docs, build-intellij-plugin]
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNEXT
 * Add slinky-react-router and slinky-history as separate subprojects, to provide interfaces to react-router and the html5 history api [PR #305](https://github.com/shadaj/slinky/pull/305)
++ Fix project build in Windows OS and add automated testing in Windows to CI workflow. You can now build Slinky and run tests in Windows [PR #308](https://github.com/shadaj/slinky/pull/308)
 
 ## [v0.6.3](https://slinky.dev)
 ### Highlights :tada:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center"><img width="400" src="https://github.com/shadaj/slinky/raw/master/logo.png"/></p>
 <p align="center"><i>Write Scala.js React apps just like you would in ES6</i></p>
 <p align="center">
-  <a href="https://travis-ci.org/shadaj/slinky">
-    <img src="https://travis-ci.org/shadaj/slinky.svg?branch=master"/>
+  <a href="https://github.com/shadaj/slinky/actions?query=branch%3Amaster">
+    <img src="https://github.com/shadaj/slinky/workflows/Slinky%20CI/badge.svg?branch=master"/>
   </a>
   <a href="https://www.scala-js.org">
     <img src="https://www.scala-js.org/assets/badges/scalajs-0.6.17.svg"/>
@@ -41,3 +41,13 @@ Slinky is split up into several submodules:
 + `docs` and `docsMacros` contains the documentation site, which is a Slinky app itself
 
 To run the main unit tests, run `sbt tests/test`.
+
+Note to IntelliJ IDEA users. When you try to import Slinky SBT definition in IDEA and encounter an exception like
+ `java.nio.file.NoSuchFileException: /Users/someuser/.slinkyPluginIC/sdk/192.6817.14/plugins`, you should
+try to download required IntelliJ files for plugin subproject manually before importing:
+
+```shell
+sbt coreIntellijSupport/updateIntellij
+```
+
+And then import the project again.

--- a/generator/src/main/scala/slinky/generator/Generator.scala
+++ b/generator/src/main/scala/slinky/generator/Generator.scala
@@ -115,7 +115,9 @@ object Generator extends App {
 
       val symbolExtends = if (symbolExtendsList.isEmpty) "" else symbolExtendsList.mkString("extends ", " with ", "")
 
-      val out = new PrintWriter(new File(outFolder.getAbsolutePath + "/" + symbol + ".scala"))
+      // Character "*" is not allowed in file names in Windows filesystem
+      val symbolFixed = if (symbol == "*") "star" else symbol
+      val out = new PrintWriter(new File(outFolder.getAbsolutePath + "/" + symbolFixed + ".scala"))
 
       out.println(
         s"""package $pkg

--- a/native/build.sbt
+++ b/native/build.sbt
@@ -3,6 +3,8 @@ enablePlugins(ScalaJSPlugin)
 import org.scalajs.core.tools.io.{MemVirtualJSFile, VirtualJSFile}
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 
+import scala.util.Properties
+
 name := "slinky-native"
 
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.8" % Test
@@ -13,6 +15,12 @@ scalaJSModuleKind in Test := ModuleKind.CommonJSModule
 
 jsEnv in Test := new NodeJSEnv() {
   override def customInitFiles(): Seq[VirtualJSFile] = super.customInitFiles() :+ new MemVirtualJSFile("addReactNativeMock.js").withContent(
-    s"""require("${(baseDirectory.value / "node_modules/react-native-mock-render/mock.js").getAbsolutePath}");"""
+    s"""require("${escapeBackslashes((baseDirectory.value / "node_modules/react-native-mock-render/mock.js").getAbsolutePath)}");"""
   )
 }
+
+def escapeBackslashes(path: String): String =
+  if (Properties.isWin)
+    path.replace("\\", "\\\\")
+  else
+    path

--- a/native/build.sbt
+++ b/native/build.sbt
@@ -19,8 +19,9 @@ jsEnv in Test := new NodeJSEnv() {
   )
 }
 
-def escapeBackslashes(path: String): String =
+def escapeBackslashes(path: String): String = {
   if (Properties.isWin)
     path.replace("\\", "\\\\")
   else
     path
+}


### PR DESCRIPTION
Fixed build in Windows OS. I think it will be helpful since not all contributors use Linux for development. I also added standalone job to CI workflow for testing in Windows, but left publication stage not dependent on it. Currently Windows tests works as simple "health" indicator but do not block anything in CI pipeline.
