### PR TITLE
Add ARIA role attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNEXT
 * Add slinky-react-router and slinky-history as separate subprojects, to provide interfaces to react-router and the html5 history api [PR #305](https://github.com/shadaj/slinky/pull/305)
++ Add ARIA role attribute [PR #309](https://github.com/shadaj/slinky/pull/309)
 
 ## [v0.6.3](https://slinky.dev)
 ### Highlights :tada:

--- a/web/html.json
+++ b/web/html.json
@@ -1858,6 +1858,15 @@
       "withDash" : true
     },
     {
+      "attributeName" : "role",
+      "attributeType" : "String",
+      "docLines" : [
+        ""
+      ],
+      "compatibleTags" : null,
+      "withDash" : false
+    },
+    {
       "attributeName" : "min",
       "attributeType" : "String",
       "docLines" : [


### PR DESCRIPTION
According to [HTML 5.2](https://www.w3.org/TR/html52/dom.html#aria-role-attribute):

> Every HTML element may have an ARIA role attribute specified. This is an ARIA Role attribute as defined by [wai-aria-1.1].

> The attribute, if specified, must have a value that is a set of space-separated tokens; each token must be a non-abstract role defined in the WAI-ARIA specification [wai-aria-1.1].