### PR TITLE
Flesh out history and react router dom facades

### DIFF
--- a/history/src/main/scala/slinky/history/History.scala
+++ b/history/src/main/scala/slinky/history/History.scala
@@ -7,7 +7,15 @@ import scala.scalajs.js.annotation.JSImport
 
 @js.native
 trait RichHistory extends History {
+  def action: String = js.native
+  def block(prompt: Boolean = false): Unit = js.native
+  def createHref(location: String): Unit = js.native
+  def goBack(): Unit = js.native
+  def goForward(): Unit = js.native
   def listen(listener: js.Function0[Unit]): Unit = js.native
+  def location: String = js.native
+  def push(route: String): Unit = js.native
+  def replace(path: String, state: js.Object): Unit = js.native
 }
 
 @JSImport("history", JSImport.Default)

--- a/reactrouter/src/main/scala/slinky/reactrouter/ReactRouterDOM.scala
+++ b/reactrouter/src/main/scala/slinky/reactrouter/ReactRouterDOM.scala
@@ -12,6 +12,7 @@ import scala.scalajs.js.annotation.JSImport
 @js.native
 object ReactRouter extends js.Object {
   val StaticRouter: js.Object = js.native
+  val MemoryRouter: js.Object = js.native
 }
 
 @JSImport("react-router-dom", JSImport.Default)
@@ -19,10 +20,13 @@ object ReactRouter extends js.Object {
 object ReactRouterDOM extends js.Object {
   val Router: js.Object = js.native
   val BrowserRouter: js.Object = js.native
+  val HashRouter: js.Object = js.native
   val Route: js.Object = js.native
   val Switch : js.Object = js.native
   val Link: js.Object = js.native
   val NavLink: js.Object = js.native
+  val Redirect: js.Object = js.native
+  val Prompt: js.Object = js.native
 }
 
 @react object StaticRouter extends ExternalComponent {
@@ -52,6 +56,11 @@ object Switch extends ExternalComponentNoProps {
 @react object Link extends ExternalComponentWithAttributes[a.tag.type] {
   case class Props(to: String)
   override val component = ReactRouterDOM.Link
+}
+
+@react object Redirect extends ExternalComponent {
+  case class Props(to: String, push: Boolean = false)
+  override val component = ReactRouterDOM.Redirect
 }
 
 @react object NavLink extends ExternalComponentWithAttributes[a.tag.type] {


### PR DESCRIPTION
Adding members to RichHistory, provided by createBrowserHistory:
https://github.com/ReactTraining/history/blob/v4.7.2/modules/createBrowserHistory.js#L295

Also adding members to react-router-dom:
https://github.com/ReactTraining/react-router/tree/v5.0.0/packages/react-router-dom

I'm just using this so far for the Redirect component, but I'm happy to spend a bit more time to add more related facade features to this after a review if you would like.