### PR TITLE
Add apply method for constructing CustomTag and CustomAttributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 + Add ARIA role attribute [PR #309](https://github.com/shadaj/slinky/pull/309)
 + Support className and role attributes for SVG [PR #314](https://github.com/shadaj/slinky/pull/314)
 + Add novalidate attribute to form [PR #315](https://github.com/shadaj/slinky/pull/315)
++ Add apply method for constructing CustomTag and CustomAttributes [PR #318](https://github.com/shadaj/slinky/pull/318)
 
 ## [v0.6.3](https://slinky.dev)
 ### Highlights :tada:

--- a/core/src/main/scala/slinky/core/TagComponent.scala
+++ b/core/src/main/scala/slinky/core/TagComponent.scala
@@ -7,7 +7,7 @@ import scala.scalajs.js
 import scala.scalajs.js.{Dictionary, JSON}
 import scala.language.higherKinds
 
-trait Tag extends Any {
+trait Tag {
   type tagType <: TagElement
   def apply(mods: TagMod[tagType]*): WithAttrs[tagType]
 }
@@ -18,6 +18,9 @@ final class CustomTag(@inline private val name: String) extends Tag {
   @inline def apply(mods: TagMod[tagType]*): WithAttrs[tagType] = {
     WithAttrs[tagType](name, mods)
   }
+}
+object CustomTag {
+  def apply(name: String): CustomTag = new CustomTag(name)
 }
 
 trait Attr {
@@ -32,6 +35,9 @@ abstract class TagElement {
 final class CustomAttribute[T](@inline private val name: String) {
   @inline def :=(v: T) = new AttrPair[Any](name, v.asInstanceOf[js.Any])
   @inline def :=(v: Option[T]) = new OptionalAttrPair[Any](name, v.asInstanceOf[Option[js.Any]])
+}
+object CustomAttribute {
+  def apply[T](name: String): CustomAttribute[T] = new CustomAttribute[T](name)
 }
 
 trait TagMod[-A] extends js.Object

--- a/docs/public/docs/custom-tags-and-attributes.md
+++ b/docs/public/docs/custom-tags-and-attributes.md
@@ -5,7 +5,7 @@ While Slinky's web module comes with a standard set of HTML and SVG tags and att
 To create a custom tag, you can use the `CustomTag` class. Simply construct this class, and use the variable it's stored in as a regular Slinky tag. Custom tags are untyped in relation to attribute support, so you can use existing Slinky attributes with them.
 
 ```scala
-val myCustomTag = new CustomTag("my-custom-element")
+val myCustomTag = CustomTag("my-custom-element")
 
 div(
   myCustomTag(href := "foo")("hello!")
@@ -24,7 +24,7 @@ results in
 To create a custom attribute, you can use the `CustomAttribute` class. Just like `CustomTag`, you can use the construct the class and use the variable it's stored in as a regular attribute. `CustomAttribute` takes a type parameter for statically typing the value of the attribute, but is untyped in relation to tag support so can be used with existing Slinky tags and custom tags.
 
 ```scala
-val myCustomAttr = new CustomAttribute[String]("custom-href")
+val myCustomAttr = CustomAttribute[String]("custom-href")
 div(myCustomAttr := "foo")
 ```
 

--- a/docs/src/main/scala/slinky/docs/Main.scala
+++ b/docs/src/main/scala/slinky/docs/Main.scala
@@ -44,7 +44,7 @@ object Main {
   }
 
   def insideRouter: ReactElement = {
-    val charSet = new CustomAttribute[String]("charSet")
+    val charSet = CustomAttribute[String]("charSet")
     div(
       Helmet(
         meta(charSet := "utf-8"),

--- a/tests/src/test/scala/slinky/core/TagTest.scala
+++ b/tests/src/test/scala/slinky/core/TagTest.scala
@@ -11,9 +11,9 @@ import org.scalajs.dom
 import org.scalajs.dom.{Element, html, Event, MouseEvent}
 
 class InnerClassCustom extends js.Object {
-  val customTag = new CustomTag("custom-element")
-  val customClass = new CustomAttribute[String]("class")
-  val customColorAttr = new CustomAttribute[String]("color")
+  val customTag = CustomTag("custom-element")
+  val customClass = CustomAttribute[String]("class")
+  val customColorAttr = CustomAttribute[String]("color")
 
   def run(): Unit = {
     val divContainer = dom.document.createElement("div")
@@ -36,7 +36,7 @@ class TagTest extends FunSuite {
   }
 
   test("Can provide a custom tag, which is supported by all components") {
-    val customHref = new CustomAttribute[String]("href")
+    val customHref = CustomAttribute[String]("href")
 
     val instance: ReactElement = a(customHref := "foo")
     assert(instance.asInstanceOf[js.Dynamic].props.href.asInstanceOf[String] == "foo")
@@ -87,7 +87,7 @@ class TagTest extends FunSuite {
   }
 
   test("Can construct a custom tag with existing attributes") {
-    val customTag = new CustomTag("custom-element")
+    val customTag = CustomTag("custom-element")
 
     val divContainer = dom.document.createElement("div")
     ReactDOM.render(customTag(href := "foo")("hello!"), divContainer)
@@ -95,9 +95,9 @@ class TagTest extends FunSuite {
   }
 
   test("Can construct a custom tag with custom attributes") {
-    val customTag = new CustomTag("custom-element")
-    val customClass = new CustomAttribute[String]("class")
-    val customColorAttr = new CustomAttribute[String]("color")
+    val customTag = CustomTag("custom-element")
+    val customClass = CustomAttribute[String]("class")
+    val customColorAttr = CustomAttribute[String]("color")
 
     val divContainer = dom.document.createElement("div")
     ReactDOM.render(customTag(customClass := "foo", customColorAttr := "bar")("hello!"), divContainer)
@@ -105,10 +105,10 @@ class TagTest extends FunSuite {
   }
 
   test("Can construct a custom tag with optional attributes") {
-    val customTag = new CustomTag("custom-element")
-    val customClass = new CustomAttribute[String]("class")
-    val customNoneAttr = new CustomAttribute[String]("none")
-    val customSomeAttr = new CustomAttribute[String]("some")
+    val customTag = CustomTag("custom-element")
+    val customClass = CustomAttribute[String]("class")
+    val customNoneAttr = CustomAttribute[String]("none")
+    val customSomeAttr = CustomAttribute[String]("some")
 
     val divContainer = dom.document.createElement("div")
     ReactDOM.render(customTag(customClass := "foo", customNoneAttr := None, customSomeAttr := Some("bar"))("hello!"), divContainer)


### PR DESCRIPTION
I couldn't think of a case where we would need multiple instances of these with the same `name`, so it sounds like it should be case classes.