### PR TITLE
Electron doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Slinky is a framework for writing React apps in Scala with an experience just li
 Slinky lets you:
 + Write React components in Scala with an API that mirrors vanilla React
 + Implement interfaces to other React libraries with automatic conversions between Scala and JS types
-+ Write apps for React Native and React 360, including the ability to share code with web apps
++ Write apps for React Native,  React 360 and Electron, including the ability to share code with web apps
 + Develop apps iteratively with included hot-reloading support
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Slinky is a framework for writing React apps in Scala with an experience just li
 Slinky lets you:
 + Write React components in Scala with an API that mirrors vanilla React
 + Implement interfaces to other React libraries with automatic conversions between Scala and JS types
-+ Write apps for React Native,  React 360 and Electron, including the ability to share code with web apps
++ Write apps for React Native, React 360, and Electron, including the ability to share code with web apps
 + Develop apps iteratively with included hot-reloading support
 
 ## Contributing

--- a/docs/public/docs/electron.md
+++ b/docs/public/docs/electron.md
@@ -1,0 +1,23 @@
+# Electron
+Slinky web projects can also be easily published as cross-platform desktop apps via [Electron](https://www.electronjs.org/).
+
+## Creating a New Electron Project
+The easiest way to create a new Electron project is to use the [`electron` branch of Create React Scala App](https://github.com/shadaj/create-react-scala-app.g8/tree/electron). This template adds to the starter project the needed NPM packages and configuration files for your bundle to be made into an Electron app.
+
+You can use this template from the command line, having SBT and NPM:
+```shell
+sbt new shadaj/create-react-scala-app.g8 --branch electron
+```
+
+Then build the app, install the dependencies and make it with Electron.
+```shell
+sbt build
+```
+
+```shell
+npm install
+```
+
+```shell
+npm run make
+```

--- a/docs/src/main/scala/slinky/docs/DocsPage.scala
+++ b/docs/src/main/scala/slinky/docs/DocsPage.scala
@@ -14,7 +14,7 @@ import js.Dynamic.literal
 
 @react object RemarkCode {
   case class Props(children: Seq[String])
-  
+
   val component = FunctionalComponent[Props] { props =>
     if (props.children.head.contains('\n')) {
       div(className := "code-block", style := literal(
@@ -100,7 +100,8 @@ object DocsTree {
       "Writing Components" -> "/docs/writing-components/",
       "External Components" -> "/docs/external-components/",
       "Functional Components and Hooks" -> "/docs/functional-components-and-hooks/",
-      "React Native and VR" -> "/docs/native-and-vr/"
+      "React Native and VR" -> "/docs/native-and-vr/",
+      "Electron" -> "/docs/electron/",
     ),
     "Advanced Guides" -> List(
       "Technical Overview" -> "/docs/technical-overview/",


### PR DESCRIPTION
The new doc refers to a -yet to be created- branch of the official template.

The plan would be:
1. you create an `electron` branch in https://github.com/shadaj/create-react-scala-app.g8
2. I PR into it what is currently into https://github.com/mcallisto/create-react-scala-app.g8/tree/electron
3. Once merged there, then this PR can also be merged