### PR TITLE
Correct onEndReached prop for FlatList

### DIFF
--- a/native/src/main/scala/slinky/native/FlatList.scala
+++ b/native/src/main/scala/slinky/native/FlatList.scala
@@ -11,8 +11,7 @@ import scala.scalajs.js.|
 case class Separators(highlight: () => Unit, unhighlight: () => Unit, updateProps: (String, js.Object) => ReactElement)
 case class ItemLayout(length: Int, offset: Int, index: Int)
 
-case class OnEndReachedInfo(distanceFromEnd: Int)
-case class OnEndReachedEvent(info: OnEndReachedInfo)
+case class OnEndReachedEvent(distanceFromEnd: Double)
 
 case class ViewToken[T](
   item: T,


### PR DESCRIPTION
The `js.Object` returned by `onEndReached` is (stringified) something like `{"distanceFromEnd":263.00006103515625}`