### PR TITLE
Support all 2020 IntelliJ versions

### DIFF
--- a/coreIntellijSupport/src/main/resources/META-INF/intellij-compat.xml
+++ b/coreIntellijSupport/src/main/resources/META-INF/intellij-compat.xml
@@ -2,7 +2,7 @@
     <name>Slinky IntelliJ support</name>
     <description>This provides type inference for Slinky macros</description>
     <vendor>Slinky</vendor>
-    <ideaVersion since-build="2019.2.0" until-build="2020.4.0">
+    <ideaVersion since-build="2019.2.0" until-build="2020.*">
         <extension interface="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.SyntheticMembersInjector"
                    implementation="slinky.core.SlinkyInjector">
             <name>Slinky IntelliJ Support</name>


### PR DESCRIPTION
We can use wildcards to just enable the plugin for all 2020 versions.