### PR TITLE
Accommodate annotation on Props class

### DIFF
--- a/core/src/main/scala/slinky/core/annotations/react.scala
+++ b/core/src/main/scala/slinky/core/annotations/react.scala
@@ -236,7 +236,8 @@ object ReactMacrosImpl {
             case _                            => false
           }) =>
         val applyMethods = objStats.flatMap {
-          case defn @ q"case class Props[..$tparams](...${caseClassparamssRaw}) extends ..$_ { $_ => ..$_ }" =>
+          case defn @ q"$pre class Props[..$tparams](...${caseClassparamssRaw}) extends ..$_ { $_ => ..$_ }"
+              if pre.hasFlag(Flag.CASE) =>
             val caseClassparamss = caseClassparamssRaw.asInstanceOf[Seq[Seq[ValDef]]]
             val childrenParam    = caseClassparamss.flatten.find(_.name.toString == "children")
 


### PR DESCRIPTION
Given this component definition:

```scala
@react
object Foo {
  @something
  case class Props(a: Int, b: String)

  val component = FunctionalComponent[Props} { ... }
}
```

The `react` macro doesn't match `case class Props` because of the `something` annotation, and generates,

```scala
  def apply(props: Props)
```

instead of the expected,

```scala
  def apply[..$tparams](...$paramssWithoutChildren)...
```

This change fixes this, but only for functional component definitions, because they are the only ones I have tested so far.