### PR TITLE
Don't use Scala.js Bundler for building Scala.js React interop

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Style checks
         run: sbt styleCheck
       - name: Install NPM Dependencies
-        run: npm install; cd tests; npm install; cd ..; cd native; npm install; cd ..
+        run: npm install; cd tests; npm install; cd ..; cd native; npm install; cd ..; cd scalajsReactInterop; npm install; cd ..
         shell: bash
       - name: Test core and native (fastopt + fullopt)
         run: sbt +tests/test +native/test "set scalaJSStage in Global := FullOptStage" +tests/test +native/test

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -12,11 +12,6 @@ libraryDependencies ++= {
   }
 }
 
-scalacOptions ++= {
-  if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
-  else Nil
-}
-
 // Needed by useCallback due to false positive warning on implicit evidence
 scalacOptions -= "-Ywarn-unused:implicits"
 scalacOptions -= "-Wunused:implicits"

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -30,9 +30,4 @@ fullOptJS / webpackConfigFile := Some(baseDirectory.value / "webpack-opt.config.
 fastOptJS / webpackDevServerExtraArgs := Seq("--inline", "--hot")
 fastOptJS / webpackBundlingMode := BundlingMode.LibraryOnly()
 
-scalacOptions ++= {
-  if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
-  else Nil
-}
-
 addCommandAlias("dev", ";fastOptJS::startWebpackDevServer;~fastOptJS")

--- a/docs/public/docs/installation.md
+++ b/docs/public/docs/installation.md
@@ -22,8 +22,6 @@ libraryDependencies += "me.shadaj" %%% "slinky-native" % "0.6.8" // React Native
 libraryDependencies += "me.shadaj" %%% "slinky-hot" % "0.6.8" // Hot loading, requires react-proxy package
 libraryDependencies += "me.shadaj" %%% "slinky-scalajsreact-interop" % "0.6.8" // Interop with japgolly/scalajs-react
 
-scalacOptions += "-P:scalajs:sjsDefinedByDefault"
-
 // optional, but recommended; enables the @react macro annotation API
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
 // if using Scala 2.13.0, instead use

--- a/native/build.sbt
+++ b/native/build.sbt
@@ -8,11 +8,6 @@ name := "slinky-native"
 
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.9" % Test
 
-scalacOptions ++= {
-  if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
-  else Nil
-}
-
 scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
 Test / scalaJSLinkerConfig ~= { _.withESFeatures(_.withUseECMAScript2015(false)) }
 

--- a/reactrouter/build.sbt
+++ b/reactrouter/build.sbt
@@ -1,8 +1,3 @@
 enablePlugins(ScalaJSPlugin)
 
 name := "slinky-react-router"
-
-scalacOptions ++= {
-  if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
-  else Nil
-}

--- a/scalajsReactInterop/build.sbt
+++ b/scalajsReactInterop/build.sbt
@@ -20,7 +20,9 @@ libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.9" % Test
 
 Test / jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
 
-Test / jsDependencies ++= Seq(
+Test / unmanagedResourceDirectories += baseDirectory.value / "node_modules"
+
+jsDependencies ++= Seq(
   ((ProvidedJS / "react/umd/react.development.js")
     .minified("react/umd/react.production.min.js")
     .commonJSName("React")) % Test,

--- a/scalajsReactInterop/build.sbt
+++ b/scalajsReactInterop/build.sbt
@@ -21,12 +21,19 @@ libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.9" % Test
 Test / jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
 
 Test / jsDependencies ++= Seq(
-  (ProvidedJS / "react/umd/react.development.js"
-    minified "react/umd/react.production.min.js" commonJSName "React") % Test,
-  (ProvidedJS / "react-dom/umd/react-dom.development.js"
-    minified "react-dom/umd/react-dom.production.min.js" dependsOn "react/umd/react.development.js" commonJSName "ReactDOM") % Test,
-  (ProvidedJS / "react-dom/umd/react-dom-test-utils.development.js"
-    minified "react-dom/umd/react-dom-test-utils.production.min.js" dependsOn "react-dom/umd/react-dom.development.js" commonJSName "ReactTestUtils") % Test,
-  (ProvidedJS / "react-dom/umd/react-dom-server.browser.development.js"
-    minified "react-dom/umd/react-dom-server.browser.production.min.js" dependsOn "react-dom/umd/react-dom.development.js" commonJSName "ReactDOMServer") % Test
+  ((ProvidedJS / "react/umd/react.development.js")
+    .minified("react/umd/react.production.min.js")
+    .commonJSName("React")) % Test,
+  ((ProvidedJS / "react-dom/umd/react-dom.development.js")
+    .minified("react-dom/umd/react-dom.production.min.js")
+    .dependsOn("react/umd/react.development.js")
+    .commonJSName("ReactDOM")) % Test,
+  ((ProvidedJS / "react-dom/umd/react-dom-test-utils.development.js")
+    .minified("react-dom/umd/react-dom-test-utils.production.min.js")
+    .dependsOn("react-dom/umd/react-dom.development.js")
+    .commonJSName("ReactTestUtils")) % Test,
+  ((ProvidedJS / "react-dom/umd/react-dom-server.browser.development.js")
+    .minified("react-dom/umd/react-dom-server.browser.production.min.js")
+    .dependsOn("react-dom/umd/react-dom.development.js")
+    .commonJSName("ReactDOMServer")) % Test
 )

--- a/scalajsReactInterop/build.sbt
+++ b/scalajsReactInterop/build.sbt
@@ -1,4 +1,5 @@
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSPlugin)
+enablePlugins(JSDependenciesPlugin)
 
 name := "slinky-scalajsreact-interop"
 
@@ -17,13 +18,15 @@ libraryDependencies ++= {
 
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.9" % Test
 
-Test / npmDependencies += "react"     -> "16.12.0"
-Test / npmDependencies += "react-dom" -> "16.12.0"
-
-Test / requireJsDomEnv := true
 Test / jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
 
-scalacOptions ++= {
-  if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
-  else Nil
-}
+Test / jsDependencies ++= Seq(
+  (ProvidedJS / "react/umd/react.development.js"
+    minified "react/umd/react.production.min.js" commonJSName "React") % Test,
+  (ProvidedJS / "react-dom/umd/react-dom.development.js"
+    minified "react-dom/umd/react-dom.production.min.js" dependsOn "react/umd/react.development.js" commonJSName "ReactDOM") % Test,
+  (ProvidedJS / "react-dom/umd/react-dom-test-utils.development.js"
+    minified "react-dom/umd/react-dom-test-utils.production.min.js" dependsOn "react-dom/umd/react-dom.development.js" commonJSName "ReactTestUtils") % Test,
+  (ProvidedJS / "react-dom/umd/react-dom-server.browser.development.js"
+    minified "react-dom/umd/react-dom-server.browser.production.min.js" dependsOn "react-dom/umd/react-dom.development.js" commonJSName "ReactDOMServer") % Test
+)

--- a/scalajsReactInterop/package.json
+++ b/scalajsReactInterop/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "dependencies": {
+    "react": "16.12.0",
+    "react-dom": "16.12.0"
+  }
+}

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -21,8 +21,3 @@ jsDependencies ++= Seq(
   (ProvidedJS / "react-dom/umd/react-dom-server.browser.development.js"
     minified "react-dom/umd/react-dom-server.browser.production.min.js" dependsOn "react-dom/umd/react-dom.development.js" commonJSName "ReactDOMServer") % Test
 )
-
-scalacOptions ++= {
-  if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
-  else Nil
-}

--- a/vr/build.sbt
+++ b/vr/build.sbt
@@ -4,9 +4,4 @@ name := "slinky-vr"
 
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.9" % Test
 
-scalacOptions ++= {
-  if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
-  else Nil
-}
-
 scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }


### PR DESCRIPTION
The bundler plugin causes issues with Scala 3 cross builds.

Also eliminates old references to `sjsDefinedByDefault` since Scala.js 0.6.x is no longer supported.