### PR TITLE
Support returning js.Function as a cleanup handler for effect hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 + Dropped Scala.js 0.6 and upgraded 1.x line to 1.6.0 to simplify building with Scala 3.
 + Updated scalajs-dom to v2.0.0 which is cross-published for Scala 3
 
+### Bug Fixes :bug:
++ Support returning `js.Function` as the cleanup handler for effect hooks [PR #525](https://github.com/shadaj/slinky/pull/525)
+
 ## [v0.6.8](https://slinky.dev)
 ### Bug Fixes :bug:
 + Bring back the missing `dd` and `dt` tags [PR #477](https://github.com/shadaj/slinky/pull/477)

--- a/core/src/main/scala/slinky/core/facade/React.scala
+++ b/core/src/main/scala/slinky/core/facade/React.scala
@@ -196,6 +196,9 @@ object EffectCallbackReturn {
   @inline implicit def fromFunction[T](fn: () => T): EffectCallbackReturn =
     (fn: js.Function0[T]).asInstanceOf[EffectCallbackReturn]
 
+  @inline implicit def fromJSFunction[T](fn: js.Function0[T]): EffectCallbackReturn =
+    fn.asInstanceOf[EffectCallbackReturn]
+
   @inline implicit def fromAny[T](value: T): EffectCallbackReturn =
     js.undefined.asInstanceOf[EffectCallbackReturn]
 }

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -6,6 +6,7 @@ Compile / npmDependencies += "react" -> "16.13.1"
 Compile / npmDependencies += "react-dom" -> "16.13.1"
 Compile / npmDependencies += "react-proxy" -> "1.1.8"
 
+Compile / npmDependencies += "react-router" -> "5.2.0"
 Compile / npmDependencies += "react-router-dom" -> "5.2.0"
 Compile / npmDependencies += "react-syntax-highlighter" -> "9.0.1"
 Compile / npmDependencies += "remark" -> "12.0.1"

--- a/native/package.json
+++ b/native/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "react": "16.6.1",
+    "react": "16.6.3",
     "react-native": "0.58.4",
-    "react-test-renderer": "16.6.1",
+    "react-test-renderer": "16.6.3",
     "react-native-mock-render": "0.1.2"
   }
 }

--- a/tests/src/test/scala/slinky/core/HooksComponentTest.scala
+++ b/tests/src/test/scala/slinky/core/HooksComponentTest.scala
@@ -1,5 +1,6 @@
 package slinky.core
 
+import scala.scalajs.js
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalajs.dom.document
 import org.scalajs.dom.Element
@@ -167,6 +168,28 @@ class HooksComponentTest extends AsyncFunSuite {
         () => {
           promise.success(assert(true))
         }
+      }, Seq(props))
+
+      props
+    }
+    
+    ReactDOM.render(component(1), container)
+    ReactDOM.unmountComponentAtNode(container)
+
+    promise.future
+  }
+
+  test("useEffect hook unsubscribe function is called on unmount when it is a js.Function") {
+    val container = document.createElement("div")
+
+    val promise: Promise[Assertion] = Promise()
+    val cleanup: js.Function0[Unit] = () => {
+      promise.success(assert(true))
+    }
+
+    val component = FunctionalComponent[Int] { props =>
+      useEffect(() => {
+        cleanup
       }, Seq(props))
 
       props


### PR DESCRIPTION
Fixes #495