### PR TITLE
Add features: createRoot, PromiseWrapper, and react lazy

### DIFF
--- a/core/src/main/scala/slinky/core/facade/React.scala
+++ b/core/src/main/scala/slinky/core/facade/React.scala
@@ -1,13 +1,5 @@
 package slinky.core.facade
 
-import slinky.core._
-
-import scala.scalajs.js
-import js.|
-import scala.annotation.unchecked.uncheckedVariance
-import scala.scalajs.js.annotation.{JSImport, JSName}
-import scala.scalajs.js.JSConverters._
-
 @js.native
 trait ReactElement extends js.Object with ReactElementMod
 
@@ -60,6 +52,10 @@ trait ReactRef[T] extends js.Object {
   var current: T @uncheckedVariance = js.native
 }
 
+trait LazyResult[P] extends js.Object {
+  val default: FunctionalComponent[P]
+}
+
 @js.native
 @JSImport("react", JSImport.Namespace, "React")
 private[slinky] object ReactRaw extends js.Object {
@@ -78,6 +74,9 @@ private[slinky] object ReactRaw extends js.Object {
   def forwardRef[P](fn: js.Object): js.Function = js.native
 
   def memo(fn: js.Function, compare: js.UndefOr[js.Object]): js.Function = js.native
+
+  final def `lazy`[P](f: js.Function0[js.Promise[LazyResult[P]]]): FunctionalComponent[P] = js.native
+
 
   @js.native
   object Children extends js.Object {

--- a/core/src/main/scala/slinky/core/facade/React.scala
+++ b/core/src/main/scala/slinky/core/facade/React.scala
@@ -1,5 +1,13 @@
 package slinky.core.facade
 
+import slinky.core._
+
+import scala.scalajs.js
+import js.|
+import scala.annotation.unchecked.uncheckedVariance
+import scala.scalajs.js.annotation.{JSImport, JSName}
+import scala.scalajs.js.JSConverters._
+
 @js.native
 trait ReactElement extends js.Object with ReactElementMod
 

--- a/core/src/main/scala/slinky/core/facade/Suspense.scala
+++ b/core/src/main/scala/slinky/core/facade/Suspense.scala
@@ -5,6 +5,13 @@ import slinky.core.{BuildingComponent, ExternalComponent, ExternalPropsWriterPro
 
 import scala.scalajs.js
 import scala.scalajs.js.|
+import scala.concurrent.Future
+import scala.scalajs.js
+import scala.scalajs.js.JavaScriptException
+import scala.scalajs.js.JSConverters._
+import scala.util.{Failure, Success}
+import concurrent.ExecutionContext.Implicits.global
+
 
 object Suspense
     extends ExternalComponent()(new Writer[Suspense.Props] {
@@ -16,3 +23,26 @@ object Suspense
 
   def apply(fallback: ReactElement): BuildingComponent[Nothing, js.Object] = apply(Props(fallback))
 }
+
+
+object Suspended {
+
+  class PromiseWrap[T](suspend: Future[T]) extends js.Object {
+    private val pending = suspend.toJSPromise
+    private var data: Option[T] = None
+    private var throwable: Option[Throwable] = None
+
+    suspend.onComplete{
+      case Success(result) => data = Some(result)
+      case Failure(error) => throwable = Some(error)
+    }
+
+    def read(): T = (data, throwable) match {
+      case (Some(data), _) => data
+      case (None, Some(error)) => throw error
+      case _ => throw JavaScriptException(pending)
+    }
+
+  }
+}
+

--- a/web/src/main/scala/slinky/web/ReactDOM.scala
+++ b/web/src/main/scala/slinky/web/ReactDOM.scala
@@ -1,5 +1,10 @@
 package slinky.web
 
+import slinky.core.facade.{React, ReactElement, ReactInstance}
+import org.scalajs.dom.Element
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
 import org.scalajs.dom.Element
 
 @js.native

--- a/web/src/main/scala/slinky/web/ReactDOM.scala
+++ b/web/src/main/scala/slinky/web/ReactDOM.scala
@@ -1,10 +1,6 @@
 package slinky.web
 
-import slinky.core.facade.{React, ReactElement, ReactInstance}
 import org.scalajs.dom.Element
-
-import scala.scalajs.js
-import scala.scalajs.js.annotation.JSImport
 
 @js.native
 @JSImport("react-dom", JSImport.Namespace, "ReactDOM")
@@ -34,4 +30,14 @@ object ReactDOMServer extends js.Object {
 
   def renderToNodeStream(element: ReactElement): js.Object       = js.native
   def renderToStaticNodeStream(element: ReactElement): js.Object = js.native
+}
+
+trait ReactRoot extends js.Object {
+  def render(component: ReactElement): ReactInstance
+}
+
+@js.native
+@JSImport("react-dom/client", JSImport.Namespace, "ReactDOM")
+object ReactDOMClient extends js.Object {
+  def createRoot(target: Element): ReactRoot = js.native
 }


### PR DESCRIPTION
Hi,

I am very short on time and had to "throw this over the wall" but here are 3 very important React features I'm using for my own needs:

1. [createRoot is the _new_ alternative to `ReactDOM.render`](https://blog.saeloun.com/2021/07/15/react-18-adds-new-root-api.html) and if not used will limit React features to version 16
3. PromiseWrapper is a convenient helper utility to use `Suspense` for _experimental_ data fetching from any arbitrary source
    - Here's a great [article about this pattern](https://dev.to/darkmavis1980/a-practical-example-of-suspense-in-react-18-3lln)
4. React Lazy lets you lazy load modules for `Suspense`

A lot of testing is needed and code cleanup. I am hoping the Slinky community is patient with these WIP changes and is willing to help out a bit too. I will try to support more in time but I wanted to initiate the PR just to get the ball rolling with at least baseline functionality.


Thanks!