### PR TITLE
Allow `cx` and `cy` SVG attributes to be assigned to Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes :bug:
 + Fix stale version of components being rendered when hot reloading is used with module splitting ([PR #588](https://github.com/shadaj/slinky/pull/588))
 + Add support for the `key` parameter of `createPortal` ([PR #594](https://github.com/shadaj/slinky/pull/594))
++ Allow the `cx` and `cy` SVG attributes to be assigned to `String`s instead of just `Double` ([PR #617](https://github.com/shadaj/slinky/pull/617))
 
 ## [v0.7.2](https://slinky.dev) (replaced v0.7.1)
 ### Bug Fixes :bug:

--- a/web/svg.json
+++ b/web/svg.json
@@ -619,7 +619,7 @@
     },
     {
       "attributeName" : "cx",
-      "attributeType" : "Double",
+      "attributeType" : "scala.scalajs.js.Any",
       "docLines" : [
       ],
       "compatibleTags" : null,
@@ -627,7 +627,7 @@
     },
     {
       "attributeName" : "cy",
-      "attributeType" : "Double",
+      "attributeType" : "scala.scalajs.js.Any",
       "docLines" : [
       ],
       "compatibleTags" : null,


### PR DESCRIPTION
Fixes #596