### PR TITLE
Add syntactic sugar for onBeforeInput & onBeforeInputCapture

### DIFF
--- a/generator/src/main/scala/slinky/generator/Generator.scala
+++ b/generator/src/main/scala/slinky/generator/Generator.scala
@@ -14,6 +14,7 @@ object Generator {
 
     val eventToSynthetic = Map[String, String => String](
       "EventHandler" -> (t => s"slinky.core.SyntheticEvent[$t, org.scalajs.dom.Event]"),
+      "InputEventHandler" -> (t => s"slinky.web.SyntheticInputEvent[$t]"),
       "ClipboardEventHandler" -> (t => s"slinky.web.SyntheticClipboardEvent[$t]"),
       "CompositionEventHandler" -> (t => s"slinky.web.SyntheticCompositionEvent[$t]"),
       "KeyboardEventHandler" -> (t => s"slinky.web.SyntheticKeyboardEvent[$t]"),

--- a/web/html.json
+++ b/web/html.json
@@ -2214,6 +2214,18 @@
       "hasCaptureVariant" : true
     },
 
+    // Input Events
+    {
+      "attributeName" : "onBeforeInput",
+      "attributeType" : "InputEventHandler",
+      "docLines" : [
+        ""
+      ],
+      "compatibleTags" : null,
+      "withDash" : false,
+      "hasCaptureVariant" : true
+    },
+
     // Keyboard Events
     {
       "attributeName" : "onKeyDown",

--- a/web/src/main/scala/slinky/web/SyntheticInputEvent.scala
+++ b/web/src/main/scala/slinky/web/SyntheticInputEvent.scala
@@ -1,0 +1,11 @@
+package slinky.web
+
+import slinky.core.SyntheticEvent
+import scala.scalajs.js
+import org.scalajs.dom.InputEvent
+
+//https://react.dev/reference/react-dom/components/common#inputevent-handler
+@js.native
+trait SyntheticInputEvent[+TargetType] extends SyntheticEvent[TargetType, InputEvent] {
+  val data: String = js.native
+}


### PR DESCRIPTION
this intended to address part of #689 which is not covered by https://github.com/shadaj/slinky/pull/695

Add  onBeforeInput & onBeforeInputCapture handlers .

As result following code should work:

```scala
input(onBeforeInputCapture := (event => { println(s"onBeforeInputCapture, data: ${event.data}") }),
      onBeforeInput := (event => { println(s"onBeforeInput, data: ${event.data}") }))
```