### PR TITLE
Allows derivation fallback messages to be suppressed

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        scalajs: ["1.9.0"]
+        scalajs: ["1.16.0"]
         es2015_enabled: ["false", "true"]
     steps:
       - name: Configure git to disable Windows line feeds

--- a/build.sbt
+++ b/build.sbt
@@ -8,13 +8,13 @@ addCommandAlias(
   "compile:scalafix --check; test:scalafix --check; compile:scalafmtCheck; test:scalafmtCheck; scalafmtSbtCheck"
 )
 
-val scala212 = "2.12.17"
-val scala213 = "2.13.10"
-val scala3   = "3.2.2"
+val scala212 = "2.12.19"
+val scala213 = "2.13.14"
+val scala3   = "3.3.3"
 
 ThisBuild / scalaVersion := scala213
 ThisBuild / semanticdbEnabled := true
-ThisBuild / semanticdbVersion := "4.7.6"
+ThisBuild / semanticdbVersion := "4.9.9"
 
 ThisBuild / tpolecatDefaultOptionsMode := DevMode
 
@@ -46,6 +46,7 @@ addCommandAlias(
 
 lazy val crossScalaSettings = Seq(
   crossScalaVersions := Seq(scala212, scala213, scala3),
+  scalacOptions += "-Wconf:cat=unused-nowarn:s",
   Compile / unmanagedSourceDirectories ++= {
     val sourceDir = (Compile / sourceDirectory).value
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.9.0")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.16.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 

--- a/readWrite/src/main/scala-2/slinky/readwrite/GenericDeriveImpl.scala
+++ b/readWrite/src/main/scala-2/slinky/readwrite/GenericDeriveImpl.scala
@@ -148,11 +148,19 @@ abstract class GenericDeriveImpl(val c: whitebox.Context) { self =>
             createSealedTraitTypeclass(tTag.tpe, getSubclasses(symbol.asClass).toSeq)
           }
         } else {
+          val debugEnabled = Option(System.getProperty("slinky.derivation.debug"))
+            .filterNot(_.isEmpty)
+            .map(_.toLowerCase)
+            .map(v => "true".equals(v) || v.substring(0, 1) == "y")
+            .getOrElse(false)
+
           memoTree(tTag.tpe) {
-            c.echo(
-              c.enclosingPosition,
-              s"Using fallback derivation for type ${tTag.tpe} (derivation: ${getClass.getSimpleName})"
-            )
+            if (debugEnabled) {
+              c.echo(
+                c.enclosingPosition,
+                s"Using fallback derivation for type ${tTag.tpe} (derivation: ${getClass.getSimpleName})"
+              )
+            }
             createFallback(tTag.tpe)
           }
         }

--- a/tests/src/test/scala/slinky/core/HooksComponentTest.scala
+++ b/tests/src/test/scala/slinky/core/HooksComponentTest.scala
@@ -12,11 +12,11 @@ import slinky.web.ReactDOM
 import slinky.web.html._
 
 import org.scalatest.Assertion
-import scala.concurrent.Promise
+import scala.concurrent.{ExecutionContext, Promise}
 import scala.util.Try
 
 class HooksComponentTest extends AsyncFunSuite {
-  implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  implicit override def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   test("Can render a functional component with useState hook") {
     val container = document.createElement("div")


### PR DESCRIPTION
Fixes #718 

Need to update compiler targets as they are falling with newer Scala/Java versions.